### PR TITLE
fix: always show HOSTNAME column and sync auth token

### DIFF
--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -92,23 +92,8 @@ func BuildBroadcastTable(
 		}
 	}
 
-	// Hide HOSTNAME when all results come from the same host
-	// (single target like _any or a specific hostname).
-	multiHost := false
-	if len(results) > 1 {
-		first := results[0].Hostname
-		for _, r := range results[1:] {
-			if r.Hostname != first {
-				multiHost = true
-				break
-			}
-		}
-	}
-
 	var headers []string
-	if multiHost || hasErrors {
-		headers = append(headers, "HOSTNAME")
-	}
+	headers = append(headers, "HOSTNAME")
 	if hasErrors {
 		headers = append(headers, "STATUS", "ERROR")
 	}
@@ -120,9 +105,7 @@ func BuildBroadcastTable(
 	rows := make([][]string, 0, len(results))
 	for _, r := range results {
 		var row []string
-		if multiHost || hasErrors {
-			row = append(row, r.Hostname)
-		}
+		row = append(row, r.Hostname)
 		if hasErrors {
 			status := r.Status
 			if status == "" {

--- a/internal/cli/ui_public_test.go
+++ b/internal/cli/ui_public_test.go
@@ -107,10 +107,10 @@ func (suite *UIPublicTestSuite) TestBuildBroadcastTable() {
 		wantRows     [][]string
 	}{
 		{
-			name:         "when no results returns empty",
+			name:         "when no results returns hostname header only",
 			results:      []cli.ResultRow{},
 			fieldHeaders: nil,
-			wantHeaders:  nil,
+			wantHeaders:  []string{"HOSTNAME"},
 			wantRows:     [][]string{},
 		},
 		{
@@ -166,14 +166,14 @@ func (suite *UIPublicTestSuite) TestBuildBroadcastTable() {
 			},
 		},
 		{
-			name: "when single host hides hostname column",
+			name: "when single host shows hostname column",
 			results: []cli.ResultRow{
 				{Hostname: "web-01", Fields: []string{"val1"}},
 			},
 			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"DATA"},
+			wantHeaders:  []string{"HOSTNAME", "DATA"},
 			wantRows: [][]string{
-				{"val1"},
+				{"web-01", "val1"},
 			},
 		},
 		{

--- a/ui/src/lib/auth.tsx
+++ b/ui/src/lib/auth.tsx
@@ -3,7 +3,6 @@ import {
   useContext,
   useState,
   useCallback,
-  useEffect,
   type ReactNode,
 } from "react";
 import {
@@ -86,11 +85,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return ENV_TOKEN || localStorage.getItem(STORAGE_KEY_TOKEN) || null;
   });
 
-  // Keep module-level token in sync for the fetch mutator
-  useEffect(() => {
-    setAuthTokenValue(token);
-  }, [token]);
-
   const tokenRoles = token ? extractRolesFromJwt(token) : [];
   const isAuthenticated = token !== null && tokenRoles.length > 0;
 
@@ -128,11 +122,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const setToken = useCallback((t: string) => {
+    setAuthTokenValue(t);
     setTokenState(t);
     localStorage.setItem(STORAGE_KEY_TOKEN, t);
   }, []);
 
   const clearToken = useCallback(() => {
+    setAuthTokenValue(null);
     setTokenState(null);
     localStorage.removeItem(STORAGE_KEY_TOKEN);
   }, []);


### PR DESCRIPTION
## Summary

- Always display the HOSTNAME column in CLI broadcast tables — knowing which host responded is always useful context, even for single-target results
- Set the module-level auth token synchronously in `setToken`/`clearToken` instead of via `useEffect` to prevent a race where API calls fire before the token is available on first login

## Test plan

- [x] `go test ./internal/cli/...` passes
- [x] Lint clean (`just go::vet`)
- [x] Verify HOSTNAME column appears on single-target CLI commands
- [x] Verify no 401 flash on first UI login

🤖 Generated with [Claude Code](https://claude.ai/code)