### PR TITLE
feat: config validation, Viper defaults, and wire dead fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ just react::fmt    # Format UI with Prettier
 - **`internal/provider/`** - Operation implementations organized by category then domain. Browse the directory to see current providers
 - **`internal/telemetry/process/`** - Agent self-metrics (CPU%, RSS, goroutines) and process condition evaluation for heartbeat
 - **`internal/controller/notify/`** - Pluggable condition notification system: watches registry KV for condition transitions, dispatches via `Notifier` interface (`log` backend)
-- **`internal/config/`** - Viper-based config from `osapi.yaml`
+- **`internal/config/`** - Viper-based config from `osapi.yaml`. Struct fields use `validate` tags (same validator as API handlers). Defaults are set via `viper.SetDefault()` in `cmd/root.go`
 - **`pkg/sdk/`** - Go SDK for programmatic REST API access (`client/` client library). See @docs/docs/sidebar/sdk/guidelines.md for SDK development rules
 - Shared `nats-client` and `nats-server` are sibling repos linked via `replace` in `go.mod`
 - **`github/`** - Temporary GitHub org config tooling (`repos.json` for declarative repo settings, `sync.sh` for drift detection via `gh` CLI). Untracked and intended to move to its own repo.

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -75,9 +75,8 @@ func setupAgent(
 ) (*agent.Agent, *natsBundle, map[string]job.SubComponentInfo) {
 	namespace := connCfg.Namespace
 	streamName := job.ApplyNamespaceToInfraName(namespace, appConfig.NATS.Stream.Name)
-	kvBucket := job.ApplyNamespaceToInfraName(namespace, appConfig.NATS.KV.Bucket)
 
-	b := connectNATSBundle(ctx, log, connCfg, kvBucket, namespace, streamName)
+	b := connectNATSBundle(ctx, log, connCfg, namespace, streamName)
 
 	plat := platform.Detect()
 	if plat == "darwin" {

--- a/cmd/controller_setup.go
+++ b/cmd/controller_setup.go
@@ -188,9 +188,8 @@ func setupController(
 ) (ServerManager, *natsBundle) {
 	namespace := connCfg.Namespace
 	streamName := job.ApplyNamespaceToInfraName(namespace, appConfig.NATS.Stream.Name)
-	kvBucket := job.ApplyNamespaceToInfraName(namespace, appConfig.NATS.KV.Bucket)
 
-	b := connectNATSBundle(ctx, log, connCfg, kvBucket, namespace, streamName)
+	b := connectNATSBundle(ctx, log, connCfg, namespace, streamName)
 
 	validation.RegisterTargetValidator(
 		func(ctx context.Context) ([]validation.AgentTarget, error) {
@@ -241,7 +240,6 @@ func connectNATSBundle(
 	ctx context.Context,
 	log *slog.Logger,
 	connCfg config.NATSConnection,
-	kvBucket string,
 	namespace string,
 	streamName string,
 ) *natsBundle {
@@ -256,7 +254,8 @@ func connectNATSBundle(
 		cli.LogFatal(log, "failed to connect to NATS", err)
 	}
 
-	jobsKV, err := nc.CreateOrUpdateKVBucket(ctx, kvBucket)
+	jobKVConfig := cli.BuildJobKVConfig(namespace, appConfig.NATS.KV)
+	jobsKV, err := nc.CreateOrUpdateKVBucketWithConfig(ctx, jobKVConfig)
 	if err != nil {
 		cli.LogFatal(log, "failed to create KV bucket", err)
 	}
@@ -313,14 +312,7 @@ func connectNATSBundle(
 		}
 	}
 
-	jobTimeout := 30 * time.Second
-	if appConfig.Controller.API.JobTimeout != "" {
-		parsed, parseErr := time.ParseDuration(appConfig.Controller.API.JobTimeout)
-		if parseErr != nil {
-			cli.LogFatal(log, "invalid job_timeout", parseErr)
-		}
-		jobTimeout = parsed
-	}
+	jobTimeout, _ := time.ParseDuration(appConfig.Controller.API.JobTimeout)
 
 	jc, err := jobclient.New(log, nc, &jobclient.Options{
 		Timeout:    jobTimeout,

--- a/cmd/controller_setup.go
+++ b/cmd/controller_setup.go
@@ -254,8 +254,8 @@ func connectNATSBundle(
 		cli.LogFatal(log, "failed to connect to NATS", err)
 	}
 
-	kvBucket := job.ApplyNamespaceToInfraName(namespace, appConfig.NATS.KV.Bucket)
-	jobsKV, err := nc.CreateOrUpdateKVBucket(ctx, kvBucket)
+	jobKVConfig := cli.BuildJobKVConfig(namespace, appConfig.NATS.KV)
+	jobsKV, err := nc.CreateOrUpdateKVBucketWithConfig(ctx, jobKVConfig)
 	if err != nil {
 		cli.LogFatal(log, "failed to create KV bucket", err)
 	}

--- a/cmd/controller_setup.go
+++ b/cmd/controller_setup.go
@@ -254,8 +254,8 @@ func connectNATSBundle(
 		cli.LogFatal(log, "failed to connect to NATS", err)
 	}
 
-	jobKVConfig := cli.BuildJobKVConfig(namespace, appConfig.NATS.KV)
-	jobsKV, err := nc.CreateOrUpdateKVBucketWithConfig(ctx, jobKVConfig)
+	kvBucket := job.ApplyNamespaceToInfraName(namespace, appConfig.NATS.KV.Bucket)
+	jobsKV, err := nc.CreateOrUpdateKVBucket(ctx, kvBucket)
 	if err != nil {
 		cli.LogFatal(log, "failed to create KV bucket", err)
 	}

--- a/cmd/nats_setup.go
+++ b/cmd/nats_setup.go
@@ -110,8 +110,6 @@ func setupJetStream(
 	// Apply namespace to infrastructure names
 	streamName := job.ApplyNamespaceToInfraName(namespace, appConfig.NATS.Stream.Name)
 	streamSubjects := job.ApplyNamespaceToSubjects(namespace, appConfig.NATS.Stream.Subjects)
-	kvBucket := job.ApplyNamespaceToInfraName(namespace, appConfig.NATS.KV.Bucket)
-	kvResponseBucket := job.ApplyNamespaceToInfraName(namespace, appConfig.NATS.KV.ResponseBucket)
 
 	// Create JOBS stream
 	streamMaxAge, _ := time.ParseDuration(appConfig.NATS.Stream.MaxAge)
@@ -138,13 +136,15 @@ func setupJetStream(
 		return fmt.Errorf("create JOBS stream: %w", err)
 	}
 
-	// Create KV buckets
-	if _, err := nc.CreateOrUpdateKVBucket(ctx, kvBucket); err != nil {
-		return fmt.Errorf("create KV bucket %s: %w", kvBucket, err)
+	// Create KV buckets with configured settings
+	jobKVConfig := cli.BuildJobKVConfig(namespace, appConfig.NATS.KV)
+	if _, err := nc.CreateOrUpdateKVBucketWithConfig(ctx, jobKVConfig); err != nil {
+		return fmt.Errorf("create KV bucket %s: %w", jobKVConfig.Bucket, err)
 	}
 
-	if _, err := nc.CreateOrUpdateKVBucket(ctx, kvResponseBucket); err != nil {
-		return fmt.Errorf("create KV bucket %s: %w", kvResponseBucket, err)
+	responseKVConfig := cli.BuildResponseKVConfig(namespace, appConfig.NATS.KV)
+	if _, err := nc.CreateOrUpdateKVBucketWithConfig(ctx, responseKVConfig); err != nil {
+		return fmt.Errorf("create KV bucket %s: %w", responseKVConfig.Bucket, err)
 	}
 
 	// Create audit stream with configured settings

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -40,6 +41,7 @@ import (
 	"github.com/retr0h/osapi/internal/cli"
 	"github.com/retr0h/osapi/internal/config"
 	"github.com/retr0h/osapi/internal/telemetry/tracing"
+	"github.com/retr0h/osapi/internal/validation"
 )
 
 var (
@@ -111,6 +113,42 @@ func initConfig() {
 	viper.SetConfigType("yaml")
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("osapi")
+
+	// Controller defaults
+	viper.SetDefault("controller.api.port", 8080)
+	viper.SetDefault("controller.api.job_timeout", "30s")
+	viper.SetDefault("controller.metrics.port", 9090)
+
+	// NATS server defaults
+	viper.SetDefault("nats.api.port", 4222)
+	viper.SetDefault("nats.api.host", "localhost")
+
+	// NATS connection defaults (controller + agent)
+	viper.SetDefault("controller.api.nats.port", 4222)
+	viper.SetDefault("controller.api.nats.host", "localhost")
+	viper.SetDefault("agent.nats.port", 4222)
+	viper.SetDefault("agent.nats.host", "localhost")
+
+	// NATS infrastructure defaults
+	viper.SetDefault("nats.stream.name", "JOBS")
+	viper.SetDefault("nats.stream.subjects", "jobs.>")
+	viper.SetDefault("nats.kv.bucket", "job-queue")
+	viper.SetDefault("nats.kv.response_bucket", "job-responses")
+	viper.SetDefault("nats.registry.bucket", "agent-registry")
+	viper.SetDefault("nats.registry.ttl", "30s")
+
+	// Agent defaults
+	viper.SetDefault("agent.max_jobs", 10)
+	viper.SetDefault("agent.queue_group", "job-agents")
+	viper.SetDefault("agent.facts.interval", "60s")
+	viper.SetDefault("agent.conditions.memory_pressure_threshold", 90)
+	viper.SetDefault("agent.conditions.high_load_multiplier", 2.0)
+	viper.SetDefault("agent.conditions.disk_pressure_threshold", 90)
+	viper.SetDefault("agent.consumer.max_deliver", 5)
+	viper.SetDefault("agent.consumer.ack_wait", "2m")
+	viper.SetDefault("agent.consumer.max_ack_pending", 1000)
+	viper.SetDefault("agent.consumer.replay_policy", "instant")
+
 	viper.SetConfigFile(viper.GetString("osapiFile"))
 
 	if err := viper.ReadInConfig(); err != nil {
@@ -119,6 +157,16 @@ func initConfig() {
 
 	if err := viper.Unmarshal(&appConfig); err != nil {
 		cli.LogFatal(logger, "failed to unmarshal config", err, "osapiFile", viper.ConfigFileUsed())
+	}
+
+	if errMsg, ok := validation.Struct(appConfig); !ok {
+		cli.LogFatal(
+			logger,
+			"invalid config",
+			fmt.Errorf("%s", errMsg),
+			"osapiFile",
+			viper.ConfigFileUsed(),
+		)
 	}
 
 	// Auto-enable tracing in debug mode so trace_id appears in log lines.

--- a/configs/osapi.yaml
+++ b/configs/osapi.yaml
@@ -87,7 +87,7 @@ nats:
     replicas: 1
 
   dlq:
-    max_age: 7d
+    max_age: 168h # 7 days
     max_msgs: 1000
     storage: file
     replicas: 1

--- a/docs/docs/sidebar/development/development.md
+++ b/docs/docs/sidebar/development/development.md
@@ -133,6 +133,14 @@ wraps `go-playground/validator`. Validation rules are declared in OpenAPI specs
 via `x-oapi-codegen-extra-tags` and enforced at runtime by handler calls to
 `validation.Struct()` or `validation.Var()`.
 
+### Config validation
+
+Config struct fields in `internal/config/types.go` use the same `validate` tags.
+Validation runs at startup after `viper.Unmarshal()` — invalid values cause an
+immediate exit with a clear error. Defaults are set via `viper.SetDefault()` in
+`cmd/root.go` so most fields can be omitted. Use `go_duration` for Go duration
+strings. Add `required` to fields with no sensible default.
+
 ### Validation rules
 
 - **Required fields** use `validate: "required,..."` — the field must be present

--- a/docs/docs/sidebar/usage/configuration.md
+++ b/docs/docs/sidebar/usage/configuration.md
@@ -17,6 +17,24 @@ By default OSAPI looks for `/etc/osapi/osapi.yaml`. Override the path with the
 osapi -f /path/to/osapi.yaml controller start
 ```
 
+## Validation
+
+Configuration is validated at startup. If any field has an invalid value, OSAPI
+exits with a clear error message before starting any component. Validation uses
+the same `go-playground/validator` library as the API handlers.
+
+- **Required fields** must be present and non-empty (e.g., `signing_key`,
+  `bearer_token`, stream and bucket names)
+- **Port fields** must be between 1 and 65535
+- **Duration fields** must be valid Go durations (e.g., `30s`, `5m`, `1h`,
+  `720h`). The `d` (day) suffix is not supported — use hours instead (e.g.,
+  `168h` for 7 days)
+- **Condition thresholds** must be within valid ranges (1–100 for percentages,
+  `>0` for load multiplier)
+
+Most fields have sensible defaults set via Viper and can be omitted from the
+config file.
+
 ## Environment Variables
 
 Every config key can be overridden with an environment variable using the
@@ -429,7 +447,7 @@ nats:
   # ── Dead Letter Queue ─────────────────────────────────────
   dlq:
     # Maximum age of messages in the DLQ.
-    max_age: '7d'
+    max_age: '168h' # 7 days
     # Maximum number of messages retained.
     max_msgs: 1000
     # Storage backend: "file" or "memory".

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/nats-io/nats.go v1.50.0
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/opencontainers/image-spec v1.1.1
-	github.com/osapi-io/nats-client v0.0.0-20260322200309-c8bab331f583
+	github.com/osapi-io/nats-client v0.0.0-20260410233618-11a6b360afb2
 	github.com/osapi-io/nats-server v0.0.0-20260216201410-1f33dfc63848
 	github.com/prometheus-community/pro-bing v0.8.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/nats-io/nats.go v1.50.0
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/opencontainers/image-spec v1.1.1
-	github.com/osapi-io/nats-client v0.0.0-20260410233618-11a6b360afb2
+	github.com/osapi-io/nats-client v0.0.0-20260411001432-2134d1870d97
 	github.com/osapi-io/nats-server v0.0.0-20260216201410-1f33dfc63848
 	github.com/prometheus-community/pro-bing v0.8.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -731,6 +731,8 @@ github.com/osapi-io/nats-client v0.0.0-20260322200309-c8bab331f583 h1:WddbBQX9fV
 github.com/osapi-io/nats-client v0.0.0-20260322200309-c8bab331f583/go.mod h1:eqZafQKr+VWRTFsnky9Z1G3QtsZPOf1zXEzYdlegvbw=
 github.com/osapi-io/nats-client v0.0.0-20260410233618-11a6b360afb2 h1:ScHtcrjuyjwUBZBdKMBONcm26NhUlfu/wDAca1F1Sw8=
 github.com/osapi-io/nats-client v0.0.0-20260410233618-11a6b360afb2/go.mod h1:JrlF5QcwMnjxc5ng7dvm8AuH92MmTIeyPqY9eDdLRgk=
+github.com/osapi-io/nats-client v0.0.0-20260411001432-2134d1870d97 h1:2a8n2N/+E1eIiUQyI+67jOwg6XuV/G1iqy7gMiSLSD8=
+github.com/osapi-io/nats-client v0.0.0-20260411001432-2134d1870d97/go.mod h1:JrlF5QcwMnjxc5ng7dvm8AuH92MmTIeyPqY9eDdLRgk=
 github.com/osapi-io/nats-server v0.0.0-20260216201410-1f33dfc63848 h1:ELW1sTVBn5JIc17mHgd5fhpO3/7btaxJpxykG2Fe0U4=
 github.com/osapi-io/nats-server v0.0.0-20260216201410-1f33dfc63848/go.mod h1:4rzeY9jiJF/+Ej4WNwqK5HQ2sflZrEs60GxQpg3Iya8=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/go.sum
+++ b/go.sum
@@ -729,6 +729,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/osapi-io/nats-client v0.0.0-20260322200309-c8bab331f583 h1:WddbBQX9fVivF/08Vpev20z/k8k+ryzXRoyEt+OMEEw=
 github.com/osapi-io/nats-client v0.0.0-20260322200309-c8bab331f583/go.mod h1:eqZafQKr+VWRTFsnky9Z1G3QtsZPOf1zXEzYdlegvbw=
+github.com/osapi-io/nats-client v0.0.0-20260410233618-11a6b360afb2 h1:ScHtcrjuyjwUBZBdKMBONcm26NhUlfu/wDAca1F1Sw8=
+github.com/osapi-io/nats-client v0.0.0-20260410233618-11a6b360afb2/go.mod h1:JrlF5QcwMnjxc5ng7dvm8AuH92MmTIeyPqY9eDdLRgk=
 github.com/osapi-io/nats-server v0.0.0-20260216201410-1f33dfc63848 h1:ELW1sTVBn5JIc17mHgd5fhpO3/7btaxJpxykG2Fe0U4=
 github.com/osapi-io/nats-server v0.0.0-20260216201410-1f33dfc63848/go.mod h1:4rzeY9jiJF/+Ej4WNwqK5HQ2sflZrEs60GxQpg3Iya8=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/internal/agent/consumer.go
+++ b/internal/agent/consumer.go
@@ -44,6 +44,9 @@ func (a *Agent) consumeQueryJobs(
 	// Sanitize hostname for consumer names (alphanumeric and underscores only)
 	sanitizedHostname := job.SanitizeHostname(hostname)
 
+	// Use configured consumer name as prefix, falling back to empty string
+	consumerPrefix := a.consumerNamePrefix()
+
 	// Create consumers for different query patterns
 	consumers := []struct {
 		name       string
@@ -51,16 +54,16 @@ func (a *Agent) consumeQueryJobs(
 		queueGroup string
 	}{
 		{
-			name:       "query_any_" + sanitizedHostname,
+			name:       consumerPrefix + "query_any_" + sanitizedHostname,
 			filter:     job.JobsQueryPrefix + "._any",
 			queueGroup: a.appConfig.Agent.QueueGroup,
 		},
 		{
-			name:   "query_all_" + sanitizedHostname,
+			name:   consumerPrefix + "query_all_" + sanitizedHostname,
 			filter: job.JobsQueryPrefix + "._all",
 		},
 		{
-			name:   "query_direct_" + sanitizedHostname,
+			name:   consumerPrefix + "query_direct_" + sanitizedHostname,
 			filter: job.JobsQueryPrefix + ".host." + sanitizedHostname,
 		},
 	}
@@ -81,7 +84,8 @@ func (a *Agent) consumeQueryJobs(
 				queueGroup string
 			}{
 				name: fmt.Sprintf(
-					"query_label_%s_%s_%s",
+					"%squery_label_%s_%s_%s",
+					consumerPrefix,
 					key,
 					sanitizedPrefix,
 					sanitizedHostname,
@@ -140,6 +144,9 @@ func (a *Agent) consumeModifyJobs(
 	// Sanitize hostname for consumer names (alphanumeric and underscores only)
 	sanitizedHostname := job.SanitizeHostname(hostname)
 
+	// Use configured consumer name as prefix, falling back to empty string
+	consumerPrefix := a.consumerNamePrefix()
+
 	// Create consumers for different modify patterns
 	consumers := []struct {
 		name       string
@@ -147,16 +154,16 @@ func (a *Agent) consumeModifyJobs(
 		queueGroup string
 	}{
 		{
-			name:       "modify_any_" + sanitizedHostname,
+			name:       consumerPrefix + "modify_any_" + sanitizedHostname,
 			filter:     job.JobsModifyPrefix + "._any",
 			queueGroup: a.appConfig.Agent.QueueGroup,
 		},
 		{
-			name:   "modify_all_" + sanitizedHostname,
+			name:   consumerPrefix + "modify_all_" + sanitizedHostname,
 			filter: job.JobsModifyPrefix + "._all",
 		},
 		{
-			name:   "modify_direct_" + sanitizedHostname,
+			name:   consumerPrefix + "modify_direct_" + sanitizedHostname,
 			filter: job.JobsModifyPrefix + ".host." + sanitizedHostname,
 		},
 	}
@@ -173,7 +180,8 @@ func (a *Agent) consumeModifyJobs(
 				queueGroup string
 			}{
 				name: fmt.Sprintf(
-					"modify_label_%s_%s_%s",
+					"%smodify_label_%s_%s_%s",
+					consumerPrefix,
 					key,
 					sanitizedPrefix,
 					sanitizedHostname,
@@ -249,6 +257,17 @@ func (a *Agent) handleJobMessageJS(
 	}
 
 	return nil
+}
+
+// consumerNamePrefix returns the configured consumer name followed by an
+// underscore separator. When no consumer name is configured, an empty string
+// is returned so existing consumer names are unchanged.
+func (a *Agent) consumerNamePrefix() string {
+	if name := a.appConfig.Agent.Consumer.Name; name != "" {
+		return name + "_"
+	}
+
+	return ""
 }
 
 // createConsumer creates a durable JetStream consumer for the agent.

--- a/internal/agent/consumer_public_test.go
+++ b/internal/agent/consumer_public_test.go
@@ -97,6 +97,40 @@ func (s *ConsumerPublicTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
 }
 
+func (s *ConsumerPublicTestSuite) TestConsumerNamePrefix() {
+	tests := []struct {
+		name         string
+		consumerName string
+		validateFunc func(result string)
+	}{
+		{
+			name:         "when consumer name is configured returns name with underscore",
+			consumerName: "my-consumer",
+			validateFunc: func(result string) {
+				s.Equal("my-consumer_", result)
+			},
+		},
+		{
+			name:         "when consumer name is empty returns empty string",
+			consumerName: "",
+			validateFunc: func(result string) {
+				s.Equal("", result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			cfg := agent.GetAgentAppConfig(s.testAgent)
+			cfg.Agent.Consumer.Name = tt.consumerName
+			agent.SetAgentAppConfig(s.testAgent, cfg)
+
+			result := agent.ExportConsumerNamePrefix(s.testAgent)
+			tt.validateFunc(result)
+		})
+	}
+}
+
 func (s *ConsumerPublicTestSuite) TestConsumeQueryJobs() {
 	tests := []struct {
 		name       string

--- a/internal/agent/export_test.go
+++ b/internal/agent/export_test.go
@@ -304,14 +304,14 @@ func ResetUnmarshalJSON() {
 	unmarshalJSON = json.Unmarshal
 }
 
-// SetFactsInterval overrides the factsInterval for testing.
-func SetFactsInterval(d time.Duration) {
-	factsInterval = d
+// SetDefaultFactsInterval overrides the defaultFactsInterval for testing.
+func SetDefaultFactsInterval(d time.Duration) {
+	defaultFactsInterval = d
 }
 
-// ResetFactsInterval restores the default factsInterval.
-func ResetFactsInterval() {
-	factsInterval = 60 * time.Second
+// ResetDefaultFactsInterval restores the default defaultFactsInterval.
+func ResetDefaultFactsInterval() {
+	defaultFactsInterval = 60 * time.Second
 }
 
 // SetHeartbeatInterval overrides the heartbeatInterval for testing.

--- a/internal/agent/export_test.go
+++ b/internal/agent/export_test.go
@@ -153,6 +153,13 @@ func ExportCreateConsumer(
 	return a.createConsumer(ctx, streamName, consumerName, filterSubject)
 }
 
+// ExportConsumerNamePrefix exposes the private consumerNamePrefix method for testing.
+func ExportConsumerNamePrefix(
+	a *Agent,
+) string {
+	return a.consumerNamePrefix()
+}
+
 // ExportHandleJobMessageJS exposes the private handleJobMessageJS method for testing.
 func ExportHandleJobMessageJS(
 	a *Agent,

--- a/internal/agent/facts.go
+++ b/internal/agent/facts.go
@@ -29,8 +29,9 @@ import (
 	"github.com/retr0h/osapi/pkg/sdk/platform"
 )
 
-// factsInterval controls the fact refresh period.
-var factsInterval = 60 * time.Second
+// defaultFactsInterval is the fallback fact refresh period when no config
+// value is set or the configured value is unparseable.
+var defaultFactsInterval = 60 * time.Second
 
 // startFacts writes the initial facts, spawns a goroutine that
 // refreshes the entry on a ticker, and stops on ctx.Done().
@@ -44,11 +45,18 @@ func (a *Agent) startFacts(
 
 	a.writeFacts(ctx, hostname)
 
+	interval := defaultFactsInterval
+	if cfgInterval := a.appConfig.Agent.Facts.Interval; cfgInterval != "" {
+		if parsed, err := time.ParseDuration(cfgInterval); err == nil {
+			interval = parsed
+		}
+	}
+
 	a.wg.Add(1)
 	go func() {
 		defer a.wg.Done()
 
-		ticker := time.NewTicker(factsInterval)
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
 		for {

--- a/internal/agent/facts_public_test.go
+++ b/internal/agent/facts_public_test.go
@@ -244,6 +244,75 @@ func (s *FactsPublicTestSuite) TestStartFactsRefresh() {
 	}
 }
 
+func (s *FactsPublicTestSuite) TestStartFactsInterval() {
+	tests := []struct {
+		name         string
+		interval     string
+		setupMock    func()
+		validateFunc func()
+	}{
+		{
+			name:     "when facts interval is configured uses configured value",
+			interval: "20ms",
+			setupMock: func() {
+				s.mockFactsKV.EXPECT().
+					Put(gomock.Any(), "facts.test_agent", gomock.Any()).
+					Return(uint64(1), nil).
+					AnyTimes()
+			},
+			validateFunc: func() {},
+		},
+		{
+			name:     "when facts interval is empty uses default",
+			interval: "",
+			setupMock: func() {
+				s.mockFactsKV.EXPECT().
+					Put(gomock.Any(), "facts.test_agent", gomock.Any()).
+					Return(uint64(1), nil).
+					AnyTimes()
+			},
+			validateFunc: func() {},
+		},
+		{
+			name:     "when facts interval is invalid uses default",
+			interval: "7d",
+			setupMock: func() {
+				s.mockFactsKV.EXPECT().
+					Put(gomock.Any(), "facts.test_agent", gomock.Any()).
+					Return(uint64(1), nil).
+					AnyTimes()
+			},
+			validateFunc: func() {},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			tt.setupMock()
+
+			// Override the default to be very short so "empty" and "invalid"
+			// cases also tick quickly.
+			agent.SetDefaultFactsInterval(10 * time.Millisecond)
+
+			cfg := agent.GetAgentAppConfig(s.testAgent)
+			cfg.Agent.Facts.Interval = tt.interval
+			agent.SetAgentAppConfig(s.testAgent, cfg)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			agent.ExportStartFacts(ctx, s.testAgent, "test-agent")
+
+			// Wait for at least one ticker refresh
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+
+			// Wait for goroutine to finish
+			agent.WaitAgentWG(s.testAgent)
+
+			tt.validateFunc()
+		})
+	}
+}
+
 func (s *FactsPublicTestSuite) TestGetFacts() {
 	tests := []struct {
 		name         string

--- a/internal/agent/facts_public_test.go
+++ b/internal/agent/facts_public_test.go
@@ -91,7 +91,7 @@ func (s *FactsPublicTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
 	agent.ResetMarshalJSON()
 	agent.ResetUnmarshalJSON()
-	agent.ResetFactsInterval()
+	agent.ResetDefaultFactsInterval()
 }
 
 func (s *FactsPublicTestSuite) TestWriteFacts() {
@@ -229,7 +229,7 @@ func (s *FactsPublicTestSuite) TestStartFactsRefresh() {
 		s.Run(tt.name, func() {
 			tt.setupMock()
 
-			agent.SetFactsInterval(10 * time.Millisecond)
+			agent.SetDefaultFactsInterval(10 * time.Millisecond)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			agent.ExportStartFacts(ctx, s.testAgent, "test-agent")

--- a/internal/cli/nats.go
+++ b/internal/cli/nats.go
@@ -77,6 +77,44 @@ func BuildNATSAuthOptions(
 	}
 }
 
+// BuildJobKVConfig builds a jetstream.KeyValueConfig from job KV config values.
+// The returned config includes TTL, MaxBytes, Storage, and Replicas from the
+// NATSKV configuration.
+func BuildJobKVConfig(
+	namespace string,
+	kvCfg config.NATSKV,
+) jetstream.KeyValueConfig {
+	bucket := job.ApplyNamespaceToInfraName(namespace, kvCfg.Bucket)
+	ttl, _ := time.ParseDuration(kvCfg.TTL)
+
+	return jetstream.KeyValueConfig{
+		Bucket:   bucket,
+		TTL:      ttl,
+		MaxBytes: kvCfg.MaxBytes,
+		Storage:  ParseJetstreamStorageType(kvCfg.Storage),
+		Replicas: kvCfg.Replicas,
+	}
+}
+
+// BuildResponseKVConfig builds a jetstream.KeyValueConfig for the job response
+// KV bucket. It shares TTL, MaxBytes, Storage, and Replicas settings from the
+// parent NATSKV configuration.
+func BuildResponseKVConfig(
+	namespace string,
+	kvCfg config.NATSKV,
+) jetstream.KeyValueConfig {
+	bucket := job.ApplyNamespaceToInfraName(namespace, kvCfg.ResponseBucket)
+	ttl, _ := time.ParseDuration(kvCfg.TTL)
+
+	return jetstream.KeyValueConfig{
+		Bucket:   bucket,
+		TTL:      ttl,
+		MaxBytes: kvCfg.MaxBytes,
+		Storage:  ParseJetstreamStorageType(kvCfg.Storage),
+		Replicas: kvCfg.Replicas,
+	}
+}
+
 // BuildRegistryKVConfig builds a jetstream.KeyValueConfig from registry config values.
 func BuildRegistryKVConfig(
 	namespace string,

--- a/internal/cli/nats_public_test.go
+++ b/internal/cli/nats_public_test.go
@@ -148,6 +148,131 @@ func (suite *NATSPublicTestSuite) TestBuildNATSAuthOptions() {
 	}
 }
 
+func (suite *NATSPublicTestSuite) TestBuildJobKVConfig() {
+	tests := []struct {
+		name       string
+		namespace  string
+		kvCfg      config.NATSKV
+		validateFn func(jetstream.KeyValueConfig)
+	}{
+		{
+			name:      "when namespace is set",
+			namespace: "osapi",
+			kvCfg: config.NATSKV{
+				Bucket:         "job-queue",
+				ResponseBucket: "job-responses",
+				TTL:            "1h",
+				MaxBytes:       104857600,
+				Storage:        "file",
+				Replicas:       1,
+			},
+			validateFn: func(cfg jetstream.KeyValueConfig) {
+				assert.Equal(suite.T(), "osapi-job-queue", cfg.Bucket)
+				assert.Equal(suite.T(), 1*time.Hour, cfg.TTL)
+				assert.Equal(suite.T(), int64(104857600), cfg.MaxBytes)
+				assert.Equal(suite.T(), jetstream.FileStorage, cfg.Storage)
+				assert.Equal(suite.T(), 1, cfg.Replicas)
+			},
+		},
+		{
+			name:      "when namespace is empty",
+			namespace: "",
+			kvCfg: config.NATSKV{
+				Bucket:   "job-queue",
+				TTL:      "30m",
+				MaxBytes: 52428800,
+				Storage:  "memory",
+				Replicas: 3,
+			},
+			validateFn: func(cfg jetstream.KeyValueConfig) {
+				assert.Equal(suite.T(), "job-queue", cfg.Bucket)
+				assert.Equal(suite.T(), 30*time.Minute, cfg.TTL)
+				assert.Equal(suite.T(), int64(52428800), cfg.MaxBytes)
+				assert.Equal(suite.T(), jetstream.MemoryStorage, cfg.Storage)
+				assert.Equal(suite.T(), 3, cfg.Replicas)
+			},
+		},
+		{
+			name:      "when TTL is invalid defaults to zero",
+			namespace: "",
+			kvCfg: config.NATSKV{
+				Bucket:   "job-queue",
+				TTL:      "invalid",
+				MaxBytes: 0,
+				Storage:  "file",
+				Replicas: 1,
+			},
+			validateFn: func(cfg jetstream.KeyValueConfig) {
+				assert.Equal(suite.T(), time.Duration(0), cfg.TTL)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			got := cli.BuildJobKVConfig(tc.namespace, tc.kvCfg)
+
+			tc.validateFn(got)
+		})
+	}
+}
+
+func (suite *NATSPublicTestSuite) TestBuildResponseKVConfig() {
+	tests := []struct {
+		name       string
+		namespace  string
+		kvCfg      config.NATSKV
+		validateFn func(jetstream.KeyValueConfig)
+	}{
+		{
+			name:      "when namespace is set",
+			namespace: "osapi",
+			kvCfg: config.NATSKV{
+				Bucket:         "job-queue",
+				ResponseBucket: "job-responses",
+				TTL:            "1h",
+				MaxBytes:       104857600,
+				Storage:        "file",
+				Replicas:       1,
+			},
+			validateFn: func(cfg jetstream.KeyValueConfig) {
+				assert.Equal(suite.T(), "osapi-job-responses", cfg.Bucket)
+				assert.Equal(suite.T(), 1*time.Hour, cfg.TTL)
+				assert.Equal(suite.T(), int64(104857600), cfg.MaxBytes)
+				assert.Equal(suite.T(), jetstream.FileStorage, cfg.Storage)
+				assert.Equal(suite.T(), 1, cfg.Replicas)
+			},
+		},
+		{
+			name:      "when namespace is empty",
+			namespace: "",
+			kvCfg: config.NATSKV{
+				Bucket:         "job-queue",
+				ResponseBucket: "job-responses",
+				TTL:            "30m",
+				MaxBytes:       52428800,
+				Storage:        "memory",
+				Replicas:       3,
+			},
+			validateFn: func(cfg jetstream.KeyValueConfig) {
+				assert.Equal(suite.T(), "job-responses", cfg.Bucket)
+				assert.Equal(suite.T(), 30*time.Minute, cfg.TTL)
+				assert.Equal(suite.T(), int64(52428800), cfg.MaxBytes)
+				assert.Equal(suite.T(), jetstream.MemoryStorage, cfg.Storage)
+				assert.Equal(suite.T(), 3, cfg.Replicas)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			got := cli.BuildResponseKVConfig(tc.namespace, tc.kvCfg)
+
+			tc.validateFn(got)
+		})
+	}
+}
+
 func (suite *NATSPublicTestSuite) TestBuildRegistryKVConfig() {
 	tests := []struct {
 		name        string

--- a/internal/config/schema_public_test.go
+++ b/internal/config/schema_public_test.go
@@ -51,9 +51,25 @@ func (s *ConfigPublicTestSuite) TestValidate() {
 						},
 					},
 					API: config.APIServer{
+						Port: 8080,
 						Security: config.ServerSecurity{
 							SigningKey: "test-signing-key",
 						},
+					},
+					NATS: config.NATSConnection{Port: 4222},
+				},
+				NATS: config.NATS{
+					Stream:   config.NATSStream{Name: "JOBS", Subjects: "jobs.>"},
+					KV:       config.NATSKV{Bucket: "job-queue", ResponseBucket: "job-responses"},
+					Registry: config.NATSRegistry{Bucket: "agent-registry"},
+				},
+				Agent: config.AgentConfig{
+					NATS:    config.NATSConnection{Port: 4222},
+					MaxJobs: 10,
+					Conditions: config.AgentConditions{
+						MemoryPressureThreshold: 90,
+						HighLoadMultiplier:      2.0,
+						DiskPressureThreshold:   90,
 					},
 				},
 			},

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -41,20 +41,12 @@ type NotificationsConfig struct {
 	Notifier string `mapstructure:"notifier"`
 	// RenotifyInterval is how often to re-fire active conditions.
 	// Uses Go duration format (e.g., "1m", "5m", "1h"). Zero disables.
-	RenotifyInterval string `mapstructure:"renotify_interval"`
+	RenotifyInterval string `mapstructure:"renotify_interval" validate:"omitempty,go_duration"`
 }
 
 // Telemetry configuration settings.
 type Telemetry struct {
 	Tracing TracingConfig `mapstructure:"tracing,omitempty"`
-	Metrics MetricsConfig `mapstructure:"metrics,omitempty"`
-}
-
-// MetricsConfig configuration settings for Prometheus metrics.
-type MetricsConfig struct {
-	// Path is the HTTP path for the Prometheus scrape endpoint.
-	// Defaults to "/metrics" when empty.
-	Path string `mapstructure:"path"`
 }
 
 // MetricsServer configures the per-component metrics HTTP server.
@@ -64,7 +56,7 @@ type MetricsServer struct {
 	// Host the metrics server binds to.
 	Host string `mapstructure:"host"`
 	// Port the metrics server listens on.
-	Port int `mapstructure:"port"`
+	Port int `mapstructure:"port"    validate:"omitempty,min=1,max=65535"`
 }
 
 // TracingConfig configuration settings for distributed tracing.
@@ -127,7 +119,7 @@ type NATSAudit struct {
 	Stream string `mapstructure:"stream"`
 	// Subject is the base subject prefix for audit messages.
 	Subject  string `mapstructure:"subject"`
-	MaxAge   string `mapstructure:"max_age"` // e.g. "720h" (30 days)
+	MaxAge   string `mapstructure:"max_age"   validate:"omitempty,go_duration"` // e.g. "720h" (30 days)
 	MaxBytes int64  `mapstructure:"max_bytes"`
 	Storage  string `mapstructure:"storage"` // "file" or "memory"
 	Replicas int    `mapstructure:"replicas"`
@@ -136,9 +128,9 @@ type NATSAudit struct {
 // NATSRegistry configuration for the agent registry KV bucket.
 type NATSRegistry struct {
 	// Bucket is the KV bucket name for agent registration entries.
-	Bucket   string `mapstructure:"bucket"`
-	TTL      string `mapstructure:"ttl"`     // e.g. "30s"
-	Storage  string `mapstructure:"storage"` // "file" or "memory"
+	Bucket   string `mapstructure:"bucket"   validate:"required"`
+	TTL      string `mapstructure:"ttl"      validate:"omitempty,go_duration"` // e.g. "30s"
+	Storage  string `mapstructure:"storage"`                                   // "file" or "memory"
 	Replicas int    `mapstructure:"replicas"`
 }
 
@@ -146,8 +138,8 @@ type NATSRegistry struct {
 type NATSFacts struct {
 	// Bucket is the KV bucket name for agent facts entries.
 	Bucket   string `mapstructure:"bucket"`
-	TTL      string `mapstructure:"ttl"`     // e.g. "1h"
-	Storage  string `mapstructure:"storage"` // "file" or "memory"
+	TTL      string `mapstructure:"ttl"      validate:"omitempty,go_duration"` // e.g. "1h"
+	Storage  string `mapstructure:"storage"`                                   // "file" or "memory"
 	Replicas int    `mapstructure:"replicas"`
 }
 
@@ -195,10 +187,10 @@ type NATSServer struct {
 // NATSStream configuration for JetStream stream settings.
 type NATSStream struct {
 	// Name is the JetStream stream name.
-	Name string `mapstructure:"name"`
+	Name string `mapstructure:"name"     validate:"required"`
 	// Subjects is the subject filter for the stream.
-	Subjects string `mapstructure:"subjects"`
-	MaxAge   string `mapstructure:"max_age"` // e.g. "24h", "1h30m"
+	Subjects string `mapstructure:"subjects" validate:"required"`
+	MaxAge   string `mapstructure:"max_age"  validate:"omitempty,go_duration"` // e.g. "24h", "1h30m"
 	MaxMsgs  int64  `mapstructure:"max_msgs"`
 	Storage  string `mapstructure:"storage"` // "file" or "memory"
 	Replicas int    `mapstructure:"replicas"`
@@ -208,9 +200,9 @@ type NATSStream struct {
 // NATSKV configuration for KeyValue bucket settings.
 type NATSKV struct {
 	// Bucket is the KV bucket name for job definitions and status events.
-	Bucket string `mapstructure:"bucket"`
+	Bucket string `mapstructure:"bucket"          validate:"required"`
 	// ResponseBucket is the KV bucket name for agent result storage.
-	ResponseBucket string `mapstructure:"response_bucket"`
+	ResponseBucket string `mapstructure:"response_bucket" validate:"required"`
 	TTL            string `mapstructure:"ttl"` // e.g. "1h", "30m"
 	MaxBytes       int64  `mapstructure:"max_bytes"`
 	Storage        string `mapstructure:"storage"` // "file" or "memory"
@@ -240,7 +232,7 @@ type ObjectStoreBucketInfo struct {
 
 // NATSDLQ configuration for Dead Letter Queue stream settings.
 type NATSDLQ struct {
-	MaxAge   string `mapstructure:"max_age"` // e.g. "7d", "24h"
+	MaxAge   string `mapstructure:"max_age"  validate:"omitempty,go_duration"` // e.g. "7d", "24h"
 	MaxMsgs  int64  `mapstructure:"max_msgs"`
 	Storage  string `mapstructure:"storage"` // "file" or "memory"
 	Replicas int    `mapstructure:"replicas"`
@@ -251,7 +243,7 @@ type NATSConnection struct {
 	// Host the NATS server hostname.
 	Host string `mapstructure:"host"`
 	// Port the NATS server port.
-	Port int `mapstructure:"port"`
+	Port int `mapstructure:"port"           validate:"min=1,max=65535"`
 	// ClientName the NATS client name for identification.
 	ClientName string `mapstructure:"client_name"`
 	// Namespace is a prefix for all NATS subjects used by this client.
@@ -280,13 +272,13 @@ type UIConfig struct {
 // APIServer holds the HTTP server config (port + security).
 type APIServer struct {
 	// Port the server will bind to.
-	Port int `mapstructure:"port"`
+	Port int `mapstructure:"port"        validate:"min=1,max=65535"`
 	// Security contains security-related configuration for the server, such as CORS and tokens.
-	Security ServerSecurity `mapstructure:"security"    mask:"struct"`
+	Security ServerSecurity `mapstructure:"security"                                     mask:"struct"`
 	// JobTimeout is how long the controller waits for agent responses
 	// before returning partial results. Uses Go duration format.
 	// Defaults to 30s when empty.
-	JobTimeout string `mapstructure:"job_timeout"`
+	JobTimeout string `mapstructure:"job_timeout" validate:"omitempty,go_duration"`
 }
 
 // Client configuration settings.
@@ -332,7 +324,7 @@ type AgentConsumer struct {
 	// MaxDeliver is the maximum number of redelivery attempts before sending to DLQ.
 	MaxDeliver int `mapstructure:"max_deliver"`
 	// AckWait is the time to wait for an ACK before redelivering.
-	AckWait string `mapstructure:"ack_wait"` // e.g. "30s", "1m"
+	AckWait string `mapstructure:"ack_wait"        validate:"omitempty,go_duration"` // e.g. "30s", "1m"
 	// MaxAckPending is the maximum outstanding unacknowledged messages.
 	MaxAckPending int `mapstructure:"max_ack_pending"`
 	// ReplayPolicy is "instant" or "original".
@@ -344,14 +336,14 @@ type AgentConsumer struct {
 // AgentFacts configuration for the agent's facts collection settings.
 type AgentFacts struct {
 	// Interval is how often the agent collects and publishes facts.
-	Interval string `mapstructure:"interval"` // e.g. "5m", "1h"
+	Interval string `mapstructure:"interval" validate:"omitempty,go_duration"` // e.g. "5m", "1h"
 }
 
 // AgentConditions holds threshold configuration for node conditions.
 type AgentConditions struct {
-	MemoryPressureThreshold int     `mapstructure:"memory_pressure_threshold"`
-	HighLoadMultiplier      float64 `mapstructure:"high_load_multiplier"`
-	DiskPressureThreshold   int     `mapstructure:"disk_pressure_threshold"`
+	MemoryPressureThreshold int     `mapstructure:"memory_pressure_threshold" validate:"min=1,max=100"`
+	HighLoadMultiplier      float64 `mapstructure:"high_load_multiplier"      validate:"gt=0"`
+	DiskPressureThreshold   int     `mapstructure:"disk_pressure_threshold"   validate:"min=1,max=100"`
 }
 
 // ProcessConditions holds threshold configuration for process-level conditions.
@@ -384,7 +376,7 @@ type AgentConfig struct {
 	// Hostname identifies this agent instance for routing.
 	Hostname string `mapstructure:"hostname"`
 	// MaxJobs maximum number of concurrent jobs to process.
-	MaxJobs int `mapstructure:"max_jobs"`
+	MaxJobs int `mapstructure:"max_jobs"                       validate:"min=1"`
 	// Labels are key-value pairs for label-based routing (e.g., role: web, env: prod).
 	Labels map[string]string `mapstructure:"labels"`
 	// Conditions holds threshold settings for node condition evaluation.

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	cronparser "github.com/robfig/cron/v3"
@@ -55,6 +56,12 @@ func init() {
 		return instance.Var(v, "ip") == nil
 	})
 
+	// go_duration validates a Go time.Duration string (e.g., "30s", "5m", "1h", "720h").
+	_ = instance.RegisterValidation("go_duration", func(fl validator.FieldLevel) bool {
+		_, err := time.ParseDuration(fl.Field().String())
+		return err == nil
+	})
+
 	// cron_schedule validates a standard 5-field cron expression
 	// (minute hour day-of-month month day-of-week).
 	cronParser := cronparser.NewParser(
@@ -70,6 +77,12 @@ func init() {
 var customHints = map[string]func(fe validator.FieldError) string{
 	"valid_target": func(fe validator.FieldError) string {
 		return fmt.Sprintf("target agent %q not found", fe.Value())
+	},
+	"go_duration": func(fe validator.FieldError) string {
+		return fmt.Sprintf(
+			"%q is not a valid Go duration (e.g., 30s, 5m, 1h)",
+			fe.Value(),
+		)
 	},
 	"cron_schedule": func(fe validator.FieldError) string {
 		return fmt.Sprintf(

--- a/internal/validation/validation_public_test.go
+++ b/internal/validation/validation_public_test.go
@@ -386,6 +386,82 @@ func (s *ValidationPublicTestSuite) TestCronSchedule() {
 	}
 }
 
+func (s *ValidationPublicTestSuite) TestGoDuration() {
+	tests := []struct {
+		name     string
+		field    string
+		wantOK   bool
+		contains []string
+	}{
+		{
+			name:   "when valid duration 30s passes",
+			field:  "30s",
+			wantOK: true,
+		},
+		{
+			name:   "when valid duration 5m passes",
+			field:  "5m",
+			wantOK: true,
+		},
+		{
+			name:   "when valid duration 1h passes",
+			field:  "1h",
+			wantOK: true,
+		},
+		{
+			name:   "when valid duration 720h passes",
+			field:  "720h",
+			wantOK: true,
+		},
+		{
+			name:   "when invalid duration 7d fails",
+			field:  "7d",
+			wantOK: false,
+		},
+		{
+			name:   "when invalid duration abc fails",
+			field:  "abc",
+			wantOK: false,
+		},
+		{
+			name:   "when empty string passes with omitempty",
+			field:  "",
+			wantOK: true,
+		},
+		{
+			name:  "when invalid duration shows hint in struct validation",
+			field: "7d",
+			contains: []string{
+				"go_duration",
+				"is not a valid Go duration",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			if len(tt.contains) > 0 {
+				// Test through Struct() to verify hint formatting.
+				type durationReq struct {
+					MaxAge string `validate:"required,go_duration"`
+				}
+				errMsg, ok := validation.Struct(durationReq{MaxAge: tt.field})
+				s.False(ok)
+				for _, c := range tt.contains {
+					s.Contains(errMsg, c)
+				}
+			} else if tt.field == "" {
+				// Test empty string with omitempty — validation should pass.
+				_, ok := validation.Var(tt.field, "omitempty,go_duration")
+				s.Equal(tt.wantOK, ok)
+			} else {
+				_, ok := validation.Var(tt.field, "go_duration")
+				s.Equal(tt.wantOK, ok)
+			}
+		})
+	}
+}
+
 func (s *ValidationPublicTestSuite) TestAtLeastOneField() {
 	type allPointers struct {
 		Shell  *string

--- a/test/integration/osapi.yaml
+++ b/test/integration/osapi.yaml
@@ -91,7 +91,7 @@ nats:
     replicas: 1
 
   dlq:
-    max_age: 7d
+    max_age: 168h # 7 days
     max_msgs: 1000
     storage: memory
     replicas: 1

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { PageLayout } from "./components/layout/page-layout";
-import { AuthProvider, useAuth } from "./lib/auth";
+import { AuthProvider } from "./lib/auth";
+import { useAuth } from "@/hooks/use-auth";
 import { CommandRegistryProvider } from "./lib/command-registry";
 import { Dashboard } from "./pages/dashboard";
 import { Configure } from "./pages/configure";

--- a/ui/src/components/domain/agent-card.tsx
+++ b/ui/src/components/domain/agent-card.tsx
@@ -7,7 +7,7 @@ import { Text } from "@/components/ui/text";
 import { LabelTag } from "@/components/ui/label-tag";
 import { ConditionAlert } from "@/components/ui/condition-alert";
 import { MetricValue } from "@/components/ui/metric-value";
-import { useAuth } from "@/lib/auth";
+import { useAuth } from "@/hooks/use-auth";
 import {
   Monitor,
   Clock,

--- a/ui/src/components/layout/navbar.tsx
+++ b/ui/src/components/layout/navbar.tsx
@@ -10,7 +10,7 @@ import {
   Shield,
 } from "lucide-react";
 import { cn } from "@/lib/cn";
-import { useAuth } from "@/lib/auth";
+import { useAuth } from "@/hooks/use-auth";
 import { ROLES } from "@/lib/permissions";
 import { Badge } from "@/components/ui/badge";
 import { Dropdown } from "@/components/ui/dropdown";

--- a/ui/src/components/layout/page-layout.tsx
+++ b/ui/src/components/layout/page-layout.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { NetworkMapBackground } from "./network-map-background";
 import { Navbar } from "./navbar";
 import { CommandBar } from "@/components/ui/command-bar";
-import { useCommands } from "@/lib/command-registry";
+import { useCommands } from "@/hooks/use-commands";
 
 interface PageLayoutProps {
   children: ReactNode;

--- a/ui/src/components/ui/command-bar.tsx
+++ b/ui/src/components/ui/command-bar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { cn } from "@/lib/cn";
-import { useCommandRegistry } from "@/lib/command-registry";
+import { useCommandRegistry } from "@/hooks/use-commands";
 import { features } from "@/lib/features";
 import { Kbd } from "@/components/ui/kbd";
 

--- a/ui/src/hooks/use-auth.ts
+++ b/ui/src/hooks/use-auth.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { AuthContext, type AuthState } from "@/lib/auth-context";
+
+export type { AuthState };
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/ui/src/hooks/use-commands.ts
+++ b/ui/src/hooks/use-commands.ts
@@ -1,0 +1,21 @@
+import { useContext, useEffect } from "react";
+import { CommandRegistryContext, type Command } from "@/lib/command-context";
+
+export function useCommandRegistry() {
+  const ctx = useContext(CommandRegistryContext);
+  if (!ctx)
+    throw new Error(
+      "useCommandRegistry must be used within CommandRegistryProvider",
+    );
+  return ctx;
+}
+
+/**
+ * Register commands for the lifetime of the calling component.
+ * Commands are unregistered on unmount.
+ */
+export function useCommands(commands: Command[], deps: unknown[] = []) {
+  const { register } = useCommandRegistry();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => register(commands), deps);
+}

--- a/ui/src/lib/auth-context.ts
+++ b/ui/src/lib/auth-context.ts
@@ -1,0 +1,27 @@
+import { createContext } from "react";
+import type { RoleDefinition, Permission } from "@/lib/permissions";
+
+export interface AuthState {
+  /** Whether the user has a valid token */
+  isAuthenticated: boolean;
+  /** Current effective role */
+  role: RoleDefinition;
+  /** Role override from dropdown (null = use token role) */
+  roleOverride: string | null;
+  /** JWT token if provided */
+  token: string | null;
+  /** Roles extracted from JWT */
+  tokenRoles: string[];
+  /** Check if current role has a permission */
+  can: (permission: Permission) => boolean;
+  /** Check if current role has all permissions */
+  canAll: (permissions: Permission[]) => boolean;
+  /** Set the role override (dropdown) */
+  setRoleOverride: (role: string | null) => void;
+  /** Set the JWT token */
+  setToken: (token: string) => void;
+  /** Clear the token */
+  clearToken: () => void;
+}
+
+export const AuthContext = createContext<AuthState | null>(null);

--- a/ui/src/lib/auth.tsx
+++ b/ui/src/lib/auth.tsx
@@ -1,20 +1,14 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  type ReactNode,
-} from "react";
+import { useState, useCallback, type ReactNode } from "react";
 import {
   ROLES,
   getRoleByName,
   getRoleByJwtRole,
   hasPermission,
   hasAllPermissions,
-  type RoleDefinition,
   type Permission,
 } from "@/lib/permissions";
 import { setAuthToken as setAuthTokenValue } from "@/lib/auth-token";
+import { AuthContext } from "@/lib/auth-context";
 
 // ---------------------------------------------------------------------------
 // JWT decoding (no verification — that's the server's job)
@@ -34,40 +28,14 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
 function extractRolesFromJwt(token: string): string[] {
   const payload = decodeJwtPayload(token);
   if (!payload) return [];
-  // osapi puts roles in the "roles" claim
   const roles = payload.roles;
   if (Array.isArray(roles)) return roles.map(String);
   return [];
 }
 
 // ---------------------------------------------------------------------------
-// Auth context
+// Auth provider
 // ---------------------------------------------------------------------------
-
-interface AuthState {
-  /** Whether the user has a valid token */
-  isAuthenticated: boolean;
-  /** Current effective role */
-  role: RoleDefinition;
-  /** Role override from dropdown (null = use token role) */
-  roleOverride: string | null;
-  /** JWT token if provided */
-  token: string | null;
-  /** Roles extracted from JWT */
-  tokenRoles: string[];
-  /** Check if current role has a permission */
-  can: (permission: Permission) => boolean;
-  /** Check if current role has all permissions */
-  canAll: (permissions: Permission[]) => boolean;
-  /** Set the role override (dropdown) */
-  setRoleOverride: (role: string | null) => void;
-  /** Set the JWT token */
-  setToken: (token: string) => void;
-  /** Clear the token */
-  clearToken: () => void;
-}
-
-const AuthContext = createContext<AuthState | null>(null);
 
 const STORAGE_KEY_ROLE = "osapi-role-override";
 const STORAGE_KEY_TOKEN = "osapi-token";
@@ -81,25 +49,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   const [token, setTokenState] = useState<string | null>(() => {
-    // Env var takes priority, then localStorage, then null (show sign-in)
     return ENV_TOKEN || localStorage.getItem(STORAGE_KEY_TOKEN) || null;
   });
 
   const tokenRoles = token ? extractRolesFromJwt(token) : [];
   const isAuthenticated = token !== null && tokenRoles.length > 0;
 
-  // Resolve effective role: override > token > default to viewer
-  let role: RoleDefinition;
+  let role;
   if (roleOverride) {
     role = getRoleByName(roleOverride) ?? ROLES[ROLES.length - 1];
   } else if (tokenRoles.length > 0) {
-    // Use the highest-privilege role from the token
     role =
       getRoleByJwtRole(tokenRoles[0]) ??
       getRoleByName(tokenRoles[0]) ??
       ROLES[ROLES.length - 1];
   } else {
-    role = ROLES[ROLES.length - 1]; // viewer
+    role = ROLES[ROLES.length - 1];
   }
 
   const can = useCallback(
@@ -151,10 +116,4 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       {children}
     </AuthContext.Provider>
   );
-}
-
-export function useAuth(): AuthState {
-  const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
-  return ctx;
 }

--- a/ui/src/lib/command-context.ts
+++ b/ui/src/lib/command-context.ts
@@ -1,0 +1,23 @@
+import { createContext } from "react";
+
+export interface Command {
+  /** Unique command ID */
+  id: string;
+  /** Display name (shown after /) */
+  name: string;
+  /** Short description */
+  description: string;
+  /** Optional category for grouping */
+  category?: string;
+  /** The action to run */
+  action: () => void;
+}
+
+export interface CommandRegistry {
+  commands: Command[];
+  register: (commands: Command[]) => () => void;
+}
+
+export const CommandRegistryContext = createContext<CommandRegistry | null>(
+  null,
+);

--- a/ui/src/lib/command-registry.tsx
+++ b/ui/src/lib/command-registry.tsx
@@ -1,31 +1,7 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  useEffect,
-  type ReactNode,
-} from "react";
+import { useState, useCallback, type ReactNode } from "react";
+import { CommandRegistryContext, type Command } from "@/lib/command-context";
 
-export interface Command {
-  /** Unique command ID */
-  id: string;
-  /** Display name (shown after /) */
-  name: string;
-  /** Short description */
-  description: string;
-  /** Optional category for grouping */
-  category?: string;
-  /** The action to run */
-  action: () => void;
-}
-
-interface CommandRegistry {
-  commands: Command[];
-  register: (commands: Command[]) => () => void;
-}
-
-const CommandRegistryContext = createContext<CommandRegistry | null>(null);
+export type { Command };
 
 export function CommandRegistryProvider({ children }: { children: ReactNode }) {
   const [commandSets, setCommandSets] = useState<Map<symbol, Command[]>>(
@@ -51,23 +27,4 @@ export function CommandRegistryProvider({ children }: { children: ReactNode }) {
       {children}
     </CommandRegistryContext.Provider>
   );
-}
-
-export function useCommandRegistry() {
-  const ctx = useContext(CommandRegistryContext);
-  if (!ctx)
-    throw new Error(
-      "useCommandRegistry must be used within CommandRegistryProvider",
-    );
-  return ctx;
-}
-
-/**
- * Register commands for the lifetime of the calling component.
- * Commands are unregistered on unmount.
- */
-export function useCommands(commands: Command[], deps: unknown[] = []) {
-  const { register } = useCommandRegistry();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => register(commands), deps);
 }

--- a/ui/src/pages/audit.tsx
+++ b/ui/src/pages/audit.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useVimScroll } from "@/hooks/use-vim-scroll";
-import { useAuth } from "@/lib/auth";
+import { useAuth } from "@/hooks/use-auth";
 import { ContentArea } from "@/components/layout/content-area";
 import { PageHeader } from "@/components/ui/page-header";
 import { SectionLabel } from "@/components/ui/section-label";

--- a/ui/src/pages/configure.tsx
+++ b/ui/src/pages/configure.tsx
@@ -41,7 +41,7 @@ import {
   BLOCK_GROUPS,
   type BlockStatus,
 } from "@/hooks/use-stack";
-import { useCommands } from "@/lib/command-registry";
+import { useCommands } from "@/hooks/use-commands";
 import { useStacks } from "@/hooks/use-stacks";
 import { features } from "@/lib/features";
 import {
@@ -197,7 +197,7 @@ import { SectionLabel } from "@/components/ui/section-label";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Text } from "@/components/ui/text";
 import { cn } from "@/lib/cn";
-import { useAuth } from "@/lib/auth";
+import { useAuth } from "@/hooks/use-auth";
 import { BLOCK_PERMISSIONS } from "@/lib/permissions";
 import {
   Calendar,

--- a/ui/src/pages/jobs.tsx
+++ b/ui/src/pages/jobs.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useVimScroll } from "@/hooks/use-vim-scroll";
-import { useAuth } from "@/lib/auth";
+import { useAuth } from "@/hooks/use-auth";
 import { ContentArea } from "@/components/layout/content-area";
 import { PageHeader } from "@/components/ui/page-header";
 import { SectionLabel } from "@/components/ui/section-label";

--- a/ui/src/pages/roles.tsx
+++ b/ui/src/pages/roles.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from "@/components/ui/page-header";
 import { SectionLabel } from "@/components/ui/section-label";
 import { DataTable } from "@/components/ui/data-table";
 import { Text } from "@/components/ui/text";
-import { useAuth } from "@/lib/auth";
+import { useAuth } from "@/hooks/use-auth";
 import { ROLES, ALL_PERMISSIONS, BLOCK_PERMISSIONS } from "@/lib/permissions";
 import { Shield, Check, X } from "lucide-react";
 import { cn } from "@/lib/cn";

--- a/ui/src/pages/sign-in.tsx
+++ b/ui/src/pages/sign-in.tsx
@@ -5,7 +5,7 @@ import { ErrorBanner } from "@/components/ui/error-banner";
 import { FormField } from "@/components/ui/form-field";
 import { Text } from "@/components/ui/text";
 import { InfoBox } from "@/components/ui/info-box";
-import { useAuth } from "@/lib/auth";
+import { useAuth } from "@/hooks/use-auth";
 import { Key, LogIn } from "lucide-react";
 
 export function SignIn() {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -5,6 +5,9 @@ import path from 'path'
 
 export default defineConfig({
   envPrefix: 'OSAPI_',
+  build: {
+    target: 'es2022',
+  },
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Add startup config validation using `go-playground/validator` tags on config structs
- Add 22 `viper.SetDefault()` calls so most config fields can be omitted
- Fix `7d` duration values to `168h` (Go's `time.ParseDuration` doesn't support days)
- Add `go_duration` custom validator for duration string fields
- Wire up dead config fields: NATSKV settings, AgentFacts.Interval, AgentConsumer.Name
- Remove dead `MetricsConfig.Path` field
- Fix React Fast Refresh warnings by splitting contexts from hooks
- Fix Vite esbuild target to `es2022` for `import.meta` support
- Add config validation docs to CLAUDE.md, configuration.md, development.md

## Config validation

Invalid config now fails at startup with clear errors:
```
invalid config: Key: 'Config.NATS.Stream.MaxAge' Error:Field validation
for 'MaxAge' failed on the 'go_duration' tag: "24d" is not a valid Go
duration (e.g., 30s, 5m, 1h)
```

## Test plan

- [x] `go build ./...` compiles
- [x] All Go tests pass
- [x] Lint clean (`just go::vet`)
- [x] UI builds clean (`just react::build`)
- [x] UI lint clean (`just react::lint`) — zero warnings
- [x] Verify invalid duration in config fails at startup
- [x] Verify missing required fields fail at startup
- [x] Verify omitted fields use Viper defaults

🤖 Generated with [Claude Code](https://claude.ai/code)