### PR TITLE
feat: unified CLI table format with 100-char width target

### DIFF
--- a/cmd/client_node_certificate_create.go
+++ b/cmd/client_node_certificate_create.go
@@ -58,14 +58,14 @@ var clientNodeCertificateCreateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -73,8 +73,8 @@ var clientNodeCertificateCreateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_certificate_create.go
+++ b/cmd/client_node_certificate_create.go
@@ -74,7 +74,9 @@ var clientNodeCertificateCreateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_certificate_delete.go
+++ b/cmd/client_node_certificate_delete.go
@@ -69,7 +69,9 @@ var clientNodeCertificateDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_certificate_delete.go
+++ b/cmd/client_node_certificate_delete.go
@@ -53,14 +53,14 @@ var clientNodeCertificateDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeCertificateDeleteCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_certificate_list.go
+++ b/cmd/client_node_certificate_list.go
@@ -84,7 +84,9 @@ var clientNodeCertificateListCmd = &cobra.Command{
 			results,
 			[]string{"NAME", "SOURCE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_certificate_list.go
+++ b/cmd/client_node_certificate_list.go
@@ -80,11 +80,11 @@ var clientNodeCertificateListCmd = &cobra.Command{
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"NAME", "SOURCE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_certificate_update.go
+++ b/cmd/client_node_certificate_update.go
@@ -73,7 +73,9 @@ var clientNodeCertificateUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_certificate_update.go
+++ b/cmd/client_node_certificate_update.go
@@ -57,14 +57,14 @@ var clientNodeCertificateUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -72,8 +72,8 @@ var clientNodeCertificateUpdateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_command_exec.go
+++ b/cmd/client_node_command_exec.go
@@ -98,7 +98,9 @@ var clientNodeCommandExecCmd = &cobra.Command{
 			"EXIT",
 			"STDOUT",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_command_exec.go
+++ b/cmd/client_node_command_exec.go
@@ -83,30 +83,22 @@ var clientNodeCommandExecCmd = &cobra.Command{
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			durationStr := ""
-			if r.DurationMs > 0 {
-				durationStr = strconv.FormatInt(r.DurationMs, 10) + "ms"
-			}
 			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 				Fields: []string{
-					r.Stdout,
-					r.Stderr,
 					strconv.Itoa(r.ExitCode),
-					durationStr,
+					r.Stdout,
 				},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
+		tr := cli.BuildBroadcastTable(results, []string{
+			"EXIT",
 			"STDOUT",
-			"STDERR",
-			"EXIT CODE",
-			"DURATION",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_command_shell.go
+++ b/cmd/client_node_command_shell.go
@@ -81,30 +81,22 @@ var clientNodeCommandShellCmd = &cobra.Command{
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			durationStr := ""
-			if r.DurationMs > 0 {
-				durationStr = strconv.FormatInt(r.DurationMs, 10) + "ms"
-			}
 			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 				Fields: []string{
-					r.Stdout,
-					r.Stderr,
 					strconv.Itoa(r.ExitCode),
-					durationStr,
+					r.Stdout,
 				},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
+		tr := cli.BuildBroadcastTable(results, []string{
+			"EXIT",
 			"STDOUT",
-			"STDERR",
-			"EXIT CODE",
-			"DURATION",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_command_shell.go
+++ b/cmd/client_node_command_shell.go
@@ -96,7 +96,9 @@ var clientNodeCommandShellCmd = &cobra.Command{
 			"EXIT",
 			"STDOUT",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_container_docker_create.go
+++ b/cmd/client_node_container_docker_create.go
@@ -94,7 +94,9 @@ var clientContainerDockerCreateCmd = &cobra.Command{
 			results,
 			[]string{"ID", "NAME", "IMAGE", "STATE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_container_docker_create.go
+++ b/cmd/client_node_container_docker_create.go
@@ -69,7 +69,7 @@ var clientContainerDockerCreateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0)
+		results := make([]cli.ResultRow, 0)
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
@@ -77,7 +77,7 @@ var clientContainerDockerCreateCmd = &cobra.Command{
 				errPtr = &e
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -90,11 +90,11 @@ var clientContainerDockerCreateCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(
+		tr := cli.BuildMutationTable(
 			results,
 			[]string{"ID", "NAME", "IMAGE", "STATE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_container_docker_exec.go
+++ b/cmd/client_node_container_docker_exec.go
@@ -90,11 +90,11 @@ var clientContainerDockerExecCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"EXIT CODE", "STDOUT", "STDERR"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_container_docker_exec.go
+++ b/cmd/client_node_container_docker_exec.go
@@ -94,7 +94,9 @@ var clientContainerDockerExecCmd = &cobra.Command{
 			results,
 			[]string{"EXIT CODE", "STDOUT", "STDERR"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_container_docker_image_remove.go
+++ b/cmd/client_node_container_docker_image_remove.go
@@ -88,7 +88,9 @@ var clientContainerDockerImageRemoveCmd = &cobra.Command{
 			results,
 			[]string{"MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_container_docker_image_remove.go
+++ b/cmd/client_node_container_docker_image_remove.go
@@ -66,7 +66,7 @@ var clientContainerDockerImageRemoveCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0)
+		results := make([]cli.ResultRow, 0)
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
@@ -74,7 +74,7 @@ var clientContainerDockerImageRemoveCmd = &cobra.Command{
 				errPtr = &e
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -84,11 +84,11 @@ var clientContainerDockerImageRemoveCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(
+		tr := cli.BuildMutationTable(
 			results,
 			[]string{"MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_container_docker_inspect.go
+++ b/cmd/client_node_container_docker_inspect.go
@@ -117,7 +117,9 @@ var clientContainerDockerInspectCmd = &cobra.Command{
 				"NETWORK",
 			},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_container_docker_inspect.go
+++ b/cmd/client_node_container_docker_inspect.go
@@ -103,7 +103,7 @@ var clientContainerDockerInspectCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{
 				"ID",
@@ -117,7 +117,7 @@ var clientContainerDockerInspectCmd = &cobra.Command{
 				"NETWORK",
 			},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_container_docker_list.go
+++ b/cmd/client_node_container_docker_list.go
@@ -77,29 +77,22 @@ var clientContainerDockerListCmd = &cobra.Command{
 			}
 
 			for _, c := range r.Containers {
-				shortID := c.ID
-				if len(shortID) > 12 {
-					shortID = shortID[:12]
-				}
-
 				results = append(results, cli.ResultRow{
 					Hostname: r.Hostname,
 					Status:   r.Status,
 					Fields: []string{
-						shortID,
 						c.Name,
 						c.Image,
 						c.State,
-						c.Created,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
-			[]string{"ID", "NAME", "IMAGE", "STATE", "CREATED"},
+			[]string{"NAME", "IMAGE", "STATE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_container_docker_list.go
+++ b/cmd/client_node_container_docker_list.go
@@ -92,7 +92,9 @@ var clientContainerDockerListCmd = &cobra.Command{
 			results,
 			[]string{"NAME", "IMAGE", "STATE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_container_docker_pull.go
+++ b/cmd/client_node_container_docker_pull.go
@@ -83,7 +83,9 @@ var clientContainerDockerPullCmd = &cobra.Command{
 			results,
 			[]string{"IMAGE ID", "TAG", "SIZE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_container_docker_pull.go
+++ b/cmd/client_node_container_docker_pull.go
@@ -59,7 +59,7 @@ var clientContainerDockerPullCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0)
+		results := make([]cli.ResultRow, 0)
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
@@ -67,7 +67,7 @@ var clientContainerDockerPullCmd = &cobra.Command{
 				errPtr = &e
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -79,11 +79,11 @@ var clientContainerDockerPullCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(
+		tr := cli.BuildMutationTable(
 			results,
 			[]string{"IMAGE ID", "TAG", "SIZE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_container_docker_remove.go
+++ b/cmd/client_node_container_docker_remove.go
@@ -61,7 +61,7 @@ var clientContainerDockerRemoveCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0)
+		results := make([]cli.ResultRow, 0)
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
@@ -69,7 +69,7 @@ var clientContainerDockerRemoveCmd = &cobra.Command{
 				errPtr = &e
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -79,11 +79,11 @@ var clientContainerDockerRemoveCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(
+		tr := cli.BuildMutationTable(
 			results,
 			[]string{"MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_container_docker_remove.go
+++ b/cmd/client_node_container_docker_remove.go
@@ -83,7 +83,9 @@ var clientContainerDockerRemoveCmd = &cobra.Command{
 			results,
 			[]string{"MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_container_docker_start.go
+++ b/cmd/client_node_container_docker_start.go
@@ -54,7 +54,7 @@ var clientContainerDockerStartCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0)
+		results := make([]cli.ResultRow, 0)
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
@@ -62,7 +62,7 @@ var clientContainerDockerStartCmd = &cobra.Command{
 				errPtr = &e
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -72,11 +72,11 @@ var clientContainerDockerStartCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(
+		tr := cli.BuildMutationTable(
 			results,
 			[]string{"MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_container_docker_start.go
+++ b/cmd/client_node_container_docker_start.go
@@ -76,7 +76,9 @@ var clientContainerDockerStartCmd = &cobra.Command{
 			results,
 			[]string{"MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_container_docker_stop.go
+++ b/cmd/client_node_container_docker_stop.go
@@ -61,7 +61,7 @@ var clientContainerDockerStopCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0)
+		results := make([]cli.ResultRow, 0)
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
@@ -69,7 +69,7 @@ var clientContainerDockerStopCmd = &cobra.Command{
 				errPtr = &e
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -79,11 +79,11 @@ var clientContainerDockerStopCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(
+		tr := cli.BuildMutationTable(
 			results,
 			[]string{"MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_container_docker_stop.go
+++ b/cmd/client_node_container_docker_stop.go
@@ -83,7 +83,9 @@ var clientContainerDockerStopCmd = &cobra.Command{
 			results,
 			[]string{"MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_disk_get.go
+++ b/cmd/client_node_disk_get.go
@@ -89,7 +89,9 @@ var clientNodeDiskGetCmd = &cobra.Command{
 			results,
 			[]string{"MOUNT", "TOTAL", "USED", "USAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_disk_get.go
+++ b/cmd/client_node_disk_get.go
@@ -80,17 +80,16 @@ var clientNodeDiskGetCmd = &cobra.Command{
 						disk.Name,
 						cli.FormatBytes(disk.Total),
 						cli.FormatBytes(disk.Used),
-						cli.FormatBytes(disk.Free),
 						usage,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
-			[]string{"MOUNT", "TOTAL", "USED", "FREE", "USAGE"},
+			[]string{"MOUNT", "TOTAL", "USED", "USAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_file_deploy.go
+++ b/cmd/client_node_file_deploy.go
@@ -75,22 +75,22 @@ SHA-256 idempotency ensures unchanged files are not rewritten.`,
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_file_deploy.go
+++ b/cmd/client_node_file_deploy.go
@@ -90,7 +90,9 @@ SHA-256 idempotency ensures unchanged files are not rewritten.`,
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_file_status.go
+++ b/cmd/client_node_file_status.go
@@ -69,7 +69,9 @@ Reports whether the file is in-sync, drifted, or missing.`,
 			})
 		}
 		tr := cli.BuildBroadcastTable(results, []string{"PATH", "STATUS"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_file_status.go
+++ b/cmd/client_node_file_status.go
@@ -65,11 +65,11 @@ Reports whether the file is in-sync, drifted, or missing.`,
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Error:    errPtr,
-				Fields:   []string{r.Path, r.Status, r.SHA256},
+				Fields:   []string{r.Path, r.Status},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{"PATH", "STATUS", "SHA256"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildBroadcastTable(results, []string{"PATH", "STATUS"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_file_undeploy.go
+++ b/cmd/client_node_file_undeploy.go
@@ -74,7 +74,9 @@ The object store entry is preserved; only the file on disk is removed.`,
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_file_undeploy.go
+++ b/cmd/client_node_file_undeploy.go
@@ -59,22 +59,22 @@ The object store entry is preserved; only the file on disk is removed.`,
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_group_create.go
+++ b/cmd/client_node_group_create.go
@@ -76,7 +76,9 @@ var clientNodeGroupCreateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_group_create.go
+++ b/cmd/client_node_group_create.go
@@ -60,14 +60,14 @@ var clientNodeGroupCreateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -75,8 +75,8 @@ var clientNodeGroupCreateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_group_delete.go
+++ b/cmd/client_node_group_delete.go
@@ -53,14 +53,14 @@ var clientNodeGroupDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeGroupDeleteCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_group_delete.go
+++ b/cmd/client_node_group_delete.go
@@ -69,7 +69,9 @@ var clientNodeGroupDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_group_get.go
+++ b/cmd/client_node_group_get.go
@@ -80,10 +80,10 @@ var clientNodeGroupGetCmd = &cobra.Command{
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
+		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "GID", "MEMBERS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_group_get.go
+++ b/cmd/client_node_group_get.go
@@ -83,7 +83,9 @@ var clientNodeGroupGetCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "GID", "MEMBERS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_group_list.go
+++ b/cmd/client_node_group_list.go
@@ -79,10 +79,10 @@ var clientNodeGroupListCmd = &cobra.Command{
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
+		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "GID", "MEMBERS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_group_list.go
+++ b/cmd/client_node_group_list.go
@@ -82,7 +82,9 @@ var clientNodeGroupListCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "GID", "MEMBERS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_group_update.go
+++ b/cmd/client_node_group_update.go
@@ -76,7 +76,9 @@ var clientNodeGroupUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_group_update.go
+++ b/cmd/client_node_group_update.go
@@ -60,14 +60,14 @@ var clientNodeGroupUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -75,8 +75,8 @@ var clientNodeGroupUpdateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_hostname_get.go
+++ b/cmd/client_node_hostname_get.go
@@ -65,7 +65,9 @@ var clientNodeHostnameGetCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildBroadcastTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_hostname_get.go
+++ b/cmd/client_node_hostname_get.go
@@ -62,11 +62,10 @@ var clientNodeHostnameGetCmd = &cobra.Command{
 				Hostname: h.Hostname,
 				Status:   h.Status,
 				Error:    errPtr,
-				Fields:   []string{cli.FormatLabels(h.Labels)},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{"LABELS"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildBroadcastTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_hostname_update.go
+++ b/cmd/client_node_hostname_update.go
@@ -69,7 +69,9 @@ var clientNodeHostnameUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_hostname_update.go
+++ b/cmd/client_node_hostname_update.go
@@ -54,22 +54,22 @@ var clientNodeHostnameUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_load_get.go
+++ b/cmd/client_node_load_get.go
@@ -77,7 +77,9 @@ var clientNodeLoadGetCmd = &cobra.Command{
 			results,
 			[]string{"LOAD (1m)", "LOAD (5m)", "LOAD (15m)"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_load_get.go
+++ b/cmd/client_node_load_get.go
@@ -73,11 +73,11 @@ var clientNodeLoadGetCmd = &cobra.Command{
 				Fields:   []string{load1, load5, load15},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"LOAD (1m)", "LOAD (5m)", "LOAD (15m)"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_log_query.go
+++ b/cmd/client_node_log_query.go
@@ -98,18 +98,17 @@ var clientNodeLogQueryCmd = &cobra.Command{
 					Status:   r.Status,
 					Fields: []string{
 						e.Timestamp,
-						e.Priority,
 						e.Unit,
 						message,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
-			[]string{"TIMESTAMP", "PRIORITY", "UNIT", "MESSAGE"},
+			[]string{"TIMESTAMP", "UNIT", "MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_log_query.go
+++ b/cmd/client_node_log_query.go
@@ -108,7 +108,9 @@ var clientNodeLogQueryCmd = &cobra.Command{
 			results,
 			[]string{"TIMESTAMP", "UNIT", "MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_log_source.go
+++ b/cmd/client_node_log_source.go
@@ -80,7 +80,9 @@ var clientNodeLogSourceCmd = &cobra.Command{
 			results,
 			[]string{"SOURCE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_log_source.go
+++ b/cmd/client_node_log_source.go
@@ -76,11 +76,11 @@ var clientNodeLogSourceCmd = &cobra.Command{
 			}
 		}
 
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"SOURCE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_log_unit.go
+++ b/cmd/client_node_log_unit.go
@@ -99,18 +99,17 @@ var clientNodeLogUnitCmd = &cobra.Command{
 					Status:   r.Status,
 					Fields: []string{
 						e.Timestamp,
-						e.Priority,
 						e.Unit,
 						message,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
-			[]string{"TIMESTAMP", "PRIORITY", "UNIT", "MESSAGE"},
+			[]string{"TIMESTAMP", "UNIT", "MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_log_unit.go
+++ b/cmd/client_node_log_unit.go
@@ -109,7 +109,9 @@ var clientNodeLogUnitCmd = &cobra.Command{
 			results,
 			[]string{"TIMESTAMP", "UNIT", "MESSAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_memory_get.go
+++ b/cmd/client_node_memory_get.go
@@ -77,11 +77,11 @@ var clientNodeMemoryGetCmd = &cobra.Command{
 				Fields:   []string{total, used, free, usage},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"TOTAL", "USED", "FREE", "USAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_memory_get.go
+++ b/cmd/client_node_memory_get.go
@@ -81,7 +81,9 @@ var clientNodeMemoryGetCmd = &cobra.Command{
 			results,
 			[]string{"TOTAL", "USED", "FREE", "USAGE"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_dns_delete.go
+++ b/cmd/client_node_network_dns_delete.go
@@ -70,7 +70,9 @@ var clientNodeNetworkDNSDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_dns_delete.go
+++ b/cmd/client_node_network_dns_delete.go
@@ -55,22 +55,22 @@ var clientNodeNetworkDNSDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_dns_get.go
+++ b/cmd/client_node_network_dns_get.go
@@ -75,7 +75,9 @@ var clientNodeNetworkDNSGetCmd = &cobra.Command{
 			"SERVERS",
 			"SEARCH DOMAINS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_dns_get.go
+++ b/cmd/client_node_network_dns_get.go
@@ -71,11 +71,11 @@ var clientNodeNetworkDNSGetCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
+		tr := cli.BuildBroadcastTable(results, []string{
 			"SERVERS",
 			"SEARCH DOMAINS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_dns_update.go
+++ b/cmd/client_node_network_dns_update.go
@@ -65,22 +65,22 @@ var clientNodeNetworkDNSUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_dns_update.go
+++ b/cmd/client_node_network_dns_update.go
@@ -80,7 +80,9 @@ var clientNodeNetworkDNSUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_interface_create.go
+++ b/cmd/client_node_network_interface_create.go
@@ -72,7 +72,9 @@ var clientNodeNetworkInterfaceCreateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_interface_create.go
+++ b/cmd/client_node_network_interface_create.go
@@ -56,14 +56,14 @@ var clientNodeNetworkInterfaceCreateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -71,8 +71,8 @@ var clientNodeNetworkInterfaceCreateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_interface_delete.go
+++ b/cmd/client_node_network_interface_delete.go
@@ -53,14 +53,14 @@ var clientNodeNetworkInterfaceDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeNetworkInterfaceDeleteCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_interface_delete.go
+++ b/cmd/client_node_network_interface_delete.go
@@ -69,7 +69,9 @@ var clientNodeNetworkInterfaceDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_interface_list.go
+++ b/cmd/client_node_network_interface_list.go
@@ -95,7 +95,9 @@ var clientNodeNetworkInterfaceListCmd = &cobra.Command{
 			results,
 			[]string{"NAME", "IPV4", "DHCP", "PRIMARY"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_interface_list.go
+++ b/cmd/client_node_network_interface_list.go
@@ -91,11 +91,11 @@ var clientNodeNetworkInterfaceListCmd = &cobra.Command{
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"NAME", "IPV4", "DHCP", "PRIMARY"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_interface_update.go
+++ b/cmd/client_node_network_interface_update.go
@@ -55,14 +55,14 @@ var clientNodeNetworkInterfaceUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -70,8 +70,8 @@ var clientNodeNetworkInterfaceUpdateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_interface_update.go
+++ b/cmd/client_node_network_interface_update.go
@@ -71,7 +71,9 @@ var clientNodeNetworkInterfaceUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_ping.go
+++ b/cmd/client_node_network_ping.go
@@ -22,7 +22,6 @@ package cmd
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -68,26 +67,23 @@ var clientNodeNetworkPingCmd = &cobra.Command{
 				Error:    errPtr,
 				Fields: []string{
 					r.AvgRtt,
-					r.MaxRtt,
 					r.MinRtt,
+					r.MaxRtt,
 					fmt.Sprintf("%f", r.PacketLoss),
-					strconv.Itoa(r.PacketsReceived),
-					strconv.Itoa(r.PacketsSent),
 				},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
-			"AVG RTT",
-			"MAX RTT",
-			"MIN RTT",
-			"PACKET LOSS",
-			"PACKETS RECEIVED",
-			"PACKETS SENT",
+		tr := cli.BuildBroadcastTable(results, []string{
+			"AVG",
+			"MIN",
+			"MAX",
+			"LOSS",
 		})
 		cli.PrintCompactTable([]cli.Section{{
 			Title:   "Ping Response",
-			Headers: headers,
-			Rows:    rows,
+			Headers: tr.Headers,
+			Rows:    tr.Rows,
+			Errors:  tr.Errors,
 		}})
 	},
 }

--- a/cmd/client_node_network_route_create.go
+++ b/cmd/client_node_network_route_create.go
@@ -68,14 +68,14 @@ Route format: TO:VIA or TO:VIA:METRIC
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -83,8 +83,8 @@ Route format: TO:VIA or TO:VIA:METRIC
 				Fields:   []string{r.Interface},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"INTERFACE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"INTERFACE"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_route_create.go
+++ b/cmd/client_node_network_route_create.go
@@ -84,7 +84,9 @@ Route format: TO:VIA or TO:VIA:METRIC
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"INTERFACE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_route_delete.go
+++ b/cmd/client_node_network_route_delete.go
@@ -69,7 +69,9 @@ var clientNodeNetworkRouteDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"INTERFACE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_route_delete.go
+++ b/cmd/client_node_network_route_delete.go
@@ -53,14 +53,14 @@ var clientNodeNetworkRouteDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeNetworkRouteDeleteCmd = &cobra.Command{
 				Fields:   []string{r.Interface},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"INTERFACE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"INTERFACE"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_route_get.go
+++ b/cmd/client_node_network_route_get.go
@@ -84,7 +84,9 @@ var clientNodeNetworkRouteGetCmd = &cobra.Command{
 			results,
 			[]string{"DESTINATION", "GATEWAY", "INTERFACE", "METRIC"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_route_get.go
+++ b/cmd/client_node_network_route_get.go
@@ -80,11 +80,11 @@ var clientNodeNetworkRouteGetCmd = &cobra.Command{
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"DESTINATION", "GATEWAY", "INTERFACE", "METRIC"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_route_list.go
+++ b/cmd/client_node_network_route_list.go
@@ -79,11 +79,11 @@ var clientNodeNetworkRouteListCmd = &cobra.Command{
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"DESTINATION", "GATEWAY", "INTERFACE", "METRIC"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_network_route_list.go
+++ b/cmd/client_node_network_route_list.go
@@ -83,7 +83,9 @@ var clientNodeNetworkRouteListCmd = &cobra.Command{
 			results,
 			[]string{"DESTINATION", "GATEWAY", "INTERFACE", "METRIC"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_route_update.go
+++ b/cmd/client_node_network_route_update.go
@@ -81,7 +81,9 @@ Route format: TO:VIA or TO:VIA:METRIC
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"INTERFACE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_network_route_update.go
+++ b/cmd/client_node_network_route_update.go
@@ -65,14 +65,14 @@ Route format: TO:VIA or TO:VIA:METRIC
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -80,8 +80,8 @@ Route format: TO:VIA or TO:VIA:METRIC
 				Fields:   []string{r.Interface},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"INTERFACE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"INTERFACE"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_ntp_create.go
+++ b/cmd/client_node_ntp_create.go
@@ -71,7 +71,9 @@ var clientNodeNtpCreateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_ntp_create.go
+++ b/cmd/client_node_ntp_create.go
@@ -56,22 +56,22 @@ var clientNodeNtpCreateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_ntp_delete.go
+++ b/cmd/client_node_ntp_delete.go
@@ -52,22 +52,22 @@ var clientNodeNtpDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_ntp_delete.go
+++ b/cmd/client_node_ntp_delete.go
@@ -67,7 +67,9 @@ var clientNodeNtpDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_ntp_get.go
+++ b/cmd/client_node_ntp_get.go
@@ -71,18 +71,16 @@ var clientNodeNtpGetCmd = &cobra.Command{
 				Error:    errPtr,
 				Fields: []string{
 					synchronized,
-					fmt.Sprintf("%d", r.Stratum),
-					r.Offset,
 					r.CurrentSource,
 					strings.Join(r.Servers, ", "),
 				},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
-			[]string{"SYNCHRONIZED", "STRATUM", "OFFSET", "SOURCE", "SERVERS"},
+			[]string{"SYNCHRONIZED", "SOURCE", "SERVERS"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_ntp_get.go
+++ b/cmd/client_node_ntp_get.go
@@ -80,7 +80,9 @@ var clientNodeNtpGetCmd = &cobra.Command{
 			results,
 			[]string{"SYNCHRONIZED", "SOURCE", "SERVERS"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_ntp_update.go
+++ b/cmd/client_node_ntp_update.go
@@ -71,7 +71,9 @@ var clientNodeNtpUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_ntp_update.go
+++ b/cmd/client_node_ntp_update.go
@@ -56,22 +56,22 @@ var clientNodeNtpUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_os_get.go
+++ b/cmd/client_node_os_get.go
@@ -76,7 +76,9 @@ var clientNodeOSGetCmd = &cobra.Command{
 			results,
 			[]string{"DISTRIBUTION", "VERSION"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_os_get.go
+++ b/cmd/client_node_os_get.go
@@ -72,11 +72,11 @@ var clientNodeOSGetCmd = &cobra.Command{
 				Fields:   []string{distribution, version},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"DISTRIBUTION", "VERSION"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_package_get.go
+++ b/cmd/client_node_package_get.go
@@ -78,7 +78,9 @@ var clientNodePackageGetCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "VERSION", "STATUS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_package_get.go
+++ b/cmd/client_node_package_get.go
@@ -64,7 +64,7 @@ var clientNodePackageGetCmd = &cobra.Command{
 					Hostname: r.Hostname,
 					Status:   r.Status,
 					Error:    errPtr,
-					Fields:   []string{p.Name, p.Version, p.Status, cli.FormatBytes(int(p.Size))},
+					Fields:   []string{p.Name, p.Version, p.Status},
 				})
 			}
 			if len(r.Packages) == 0 && r.Error != "" {
@@ -75,10 +75,10 @@ var clientNodePackageGetCmd = &cobra.Command{
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
-			"NAME", "VERSION", "STATUS", "SIZE",
+		tr := cli.BuildBroadcastTable(results, []string{
+			"NAME", "VERSION", "STATUS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_package_install.go
+++ b/cmd/client_node_package_install.go
@@ -53,14 +53,14 @@ var clientNodePackageInstallCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodePackageInstallCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_package_install.go
+++ b/cmd/client_node_package_install.go
@@ -69,7 +69,9 @@ var clientNodePackageInstallCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_package_list.go
+++ b/cmd/client_node_package_list.go
@@ -77,7 +77,9 @@ var clientNodePackageListCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "VERSION", "STATUS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_package_list.go
+++ b/cmd/client_node_package_list.go
@@ -63,7 +63,7 @@ var clientNodePackageListCmd = &cobra.Command{
 					Hostname: r.Hostname,
 					Status:   r.Status,
 					Error:    errPtr,
-					Fields:   []string{p.Name, p.Version, p.Status, cli.FormatBytes(int(p.Size))},
+					Fields:   []string{p.Name, p.Version, p.Status},
 				})
 			}
 			if len(r.Packages) == 0 && r.Error != "" {
@@ -74,10 +74,10 @@ var clientNodePackageListCmd = &cobra.Command{
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
-			"NAME", "VERSION", "STATUS", "SIZE",
+		tr := cli.BuildBroadcastTable(results, []string{
+			"NAME", "VERSION", "STATUS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_package_remove.go
+++ b/cmd/client_node_package_remove.go
@@ -53,14 +53,14 @@ var clientNodePackageRemoveCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodePackageRemoveCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_package_remove.go
+++ b/cmd/client_node_package_remove.go
@@ -69,7 +69,9 @@ var clientNodePackageRemoveCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_package_update.go
+++ b/cmd/client_node_package_update.go
@@ -68,7 +68,9 @@ var clientNodePackageUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_package_update.go
+++ b/cmd/client_node_package_update.go
@@ -53,22 +53,22 @@ var clientNodePackageUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_package_updates.go
+++ b/cmd/client_node_package_updates.go
@@ -74,10 +74,10 @@ var clientNodePackageUpdatesCmd = &cobra.Command{
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
+		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "CURRENT", "NEW",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_package_updates.go
+++ b/cmd/client_node_package_updates.go
@@ -77,7 +77,9 @@ var clientNodePackageUpdatesCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "CURRENT", "NEW",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_power_reboot.go
+++ b/cmd/client_node_power_reboot.go
@@ -75,7 +75,9 @@ var clientNodePowerRebootCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"ACTION", "DELAY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_power_reboot.go
+++ b/cmd/client_node_power_reboot.go
@@ -59,14 +59,14 @@ var clientNodePowerRebootCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -74,8 +74,8 @@ var clientNodePowerRebootCmd = &cobra.Command{
 				Fields:   []string{r.Action, strconv.Itoa(r.Delay)},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"ACTION", "DELAY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"ACTION", "DELAY"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_power_shutdown.go
+++ b/cmd/client_node_power_shutdown.go
@@ -75,7 +75,9 @@ var clientNodePowerShutdownCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"ACTION", "DELAY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_power_shutdown.go
+++ b/cmd/client_node_power_shutdown.go
@@ -59,14 +59,14 @@ var clientNodePowerShutdownCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -74,8 +74,8 @@ var clientNodePowerShutdownCmd = &cobra.Command{
 				Fields:   []string{r.Action, strconv.Itoa(r.Delay)},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"ACTION", "DELAY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"ACTION", "DELAY"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_process_get.go
+++ b/cmd/client_node_process_get.go
@@ -85,17 +85,16 @@ var clientNodeProcessGetCmd = &cobra.Command{
 						p.User,
 						p.State,
 						fmt.Sprintf("%.1f%%", p.CPUPercent),
-						fmt.Sprintf("%.1f%%", p.MemPercent),
 						command,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
-			[]string{"PID", "NAME", "USER", "STATE", "CPU%", "MEM%", "COMMAND"},
+			[]string{"PID", "NAME", "USER", "STATE", "CPU%", "COMMAND"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_process_get.go
+++ b/cmd/client_node_process_get.go
@@ -94,7 +94,9 @@ var clientNodeProcessGetCmd = &cobra.Command{
 			results,
 			[]string{"PID", "NAME", "USER", "STATE", "CPU%", "COMMAND"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_process_list.go
+++ b/cmd/client_node_process_list.go
@@ -93,7 +93,9 @@ var clientNodeProcessListCmd = &cobra.Command{
 			results,
 			[]string{"PID", "NAME", "USER", "STATE", "CPU%", "COMMAND"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_process_list.go
+++ b/cmd/client_node_process_list.go
@@ -84,17 +84,16 @@ var clientNodeProcessListCmd = &cobra.Command{
 						p.User,
 						p.State,
 						fmt.Sprintf("%.1f%%", p.CPUPercent),
-						fmt.Sprintf("%.1f%%", p.MemPercent),
 						command,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
-			[]string{"PID", "NAME", "USER", "STATE", "CPU%", "MEM%", "COMMAND"},
+			[]string{"PID", "NAME", "USER", "STATE", "CPU%", "COMMAND"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_process_signal.go
+++ b/cmd/client_node_process_signal.go
@@ -82,7 +82,9 @@ var clientNodeProcessSignalCmd = &cobra.Command{
 			results,
 			[]string{"PID", "SIGNAL", "CHANGED"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_process_signal.go
+++ b/cmd/client_node_process_signal.go
@@ -78,11 +78,11 @@ var clientNodeProcessSignalCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"PID", "SIGNAL", "CHANGED"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_schedule_cron_create.go
+++ b/cmd/client_node_schedule_cron_create.go
@@ -82,7 +82,9 @@ var clientNodeScheduleCronCreateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_schedule_cron_create.go
+++ b/cmd/client_node_schedule_cron_create.go
@@ -66,14 +66,14 @@ var clientNodeScheduleCronCreateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -81,8 +81,8 @@ var clientNodeScheduleCronCreateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_schedule_cron_delete.go
+++ b/cmd/client_node_schedule_cron_delete.go
@@ -69,7 +69,9 @@ var clientNodeScheduleCronDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_schedule_cron_delete.go
+++ b/cmd/client_node_schedule_cron_delete.go
@@ -53,14 +53,14 @@ var clientNodeScheduleCronDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeScheduleCronDeleteCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_schedule_cron_get.go
+++ b/cmd/client_node_schedule_cron_get.go
@@ -66,10 +66,10 @@ var clientNodeScheduleCronGetCmd = &cobra.Command{
 				Fields:   []string{r.Name, r.Schedule, r.Object, r.User},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
+		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "SCHEDULE", "OBJECT", "USER",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_schedule_cron_get.go
+++ b/cmd/client_node_schedule_cron_get.go
@@ -69,7 +69,9 @@ var clientNodeScheduleCronGetCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "SCHEDULE", "OBJECT", "USER",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_schedule_cron_list.go
+++ b/cmd/client_node_schedule_cron_list.go
@@ -72,7 +72,9 @@ var clientNodeScheduleCronListCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "SCHEDULE", "OBJECT", "USER",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_schedule_cron_list.go
+++ b/cmd/client_node_schedule_cron_list.go
@@ -66,13 +66,13 @@ var clientNodeScheduleCronListCmd = &cobra.Command{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Error:    errPtr,
-				Fields:   []string{r.Name, r.Source, schedule, r.Object, r.User},
+				Fields:   []string{r.Name, schedule, r.Object, r.User},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
-			"NAME", "SOURCE", "SCHEDULE", "OBJECT", "USER",
+		tr := cli.BuildBroadcastTable(results, []string{
+			"NAME", "SCHEDULE", "OBJECT", "USER",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_schedule_cron_update.go
+++ b/cmd/client_node_schedule_cron_update.go
@@ -79,7 +79,9 @@ var clientNodeScheduleCronUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_schedule_cron_update.go
+++ b/cmd/client_node_schedule_cron_update.go
@@ -63,14 +63,14 @@ var clientNodeScheduleCronUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -78,8 +78,8 @@ var clientNodeScheduleCronUpdateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_create.go
+++ b/cmd/client_node_service_create.go
@@ -74,7 +74,9 @@ var clientNodeServiceCreateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_service_create.go
+++ b/cmd/client_node_service_create.go
@@ -58,14 +58,14 @@ var clientNodeServiceCreateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -73,8 +73,8 @@ var clientNodeServiceCreateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_delete.go
+++ b/cmd/client_node_service_delete.go
@@ -53,14 +53,14 @@ var clientNodeServiceDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeServiceDeleteCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_delete.go
+++ b/cmd/client_node_service_delete.go
@@ -69,7 +69,9 @@ var clientNodeServiceDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_service_disable.go
+++ b/cmd/client_node_service_disable.go
@@ -69,7 +69,9 @@ var clientNodeServiceDisableCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_service_disable.go
+++ b/cmd/client_node_service_disable.go
@@ -53,14 +53,14 @@ var clientNodeServiceDisableCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeServiceDisableCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_enable.go
+++ b/cmd/client_node_service_enable.go
@@ -53,14 +53,14 @@ var clientNodeServiceEnableCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeServiceEnableCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_enable.go
+++ b/cmd/client_node_service_enable.go
@@ -69,7 +69,9 @@ var clientNodeServiceEnableCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_service_get.go
+++ b/cmd/client_node_service_get.go
@@ -88,7 +88,9 @@ var clientNodeServiceGetCmd = &cobra.Command{
 			results,
 			[]string{"NAME", "STATUS", "ENABLED", "DESCRIPTION"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_service_get.go
+++ b/cmd/client_node_service_get.go
@@ -80,16 +80,15 @@ var clientNodeServiceGetCmd = &cobra.Command{
 						svc.Status,
 						fmt.Sprintf("%t", svc.Enabled),
 						svc.Description,
-						fmt.Sprintf("%d", svc.PID),
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
-			[]string{"NAME", "STATUS", "ENABLED", "DESCRIPTION", "PID"},
+			[]string{"NAME", "STATUS", "ENABLED", "DESCRIPTION"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_list.go
+++ b/cmd/client_node_service_list.go
@@ -77,16 +77,15 @@ var clientNodeServiceListCmd = &cobra.Command{
 						svc.Name,
 						svc.Status,
 						fmt.Sprintf("%t", svc.Enabled),
-						svc.Description,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
-			[]string{"NAME", "STATUS", "ENABLED", "DESCRIPTION"},
+			[]string{"NAME", "STATUS", "ENABLED"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_list.go
+++ b/cmd/client_node_service_list.go
@@ -85,7 +85,9 @@ var clientNodeServiceListCmd = &cobra.Command{
 			results,
 			[]string{"NAME", "STATUS", "ENABLED"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_service_restart.go
+++ b/cmd/client_node_service_restart.go
@@ -53,14 +53,14 @@ var clientNodeServiceRestartCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeServiceRestartCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_restart.go
+++ b/cmd/client_node_service_restart.go
@@ -69,7 +69,9 @@ var clientNodeServiceRestartCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_service_start.go
+++ b/cmd/client_node_service_start.go
@@ -69,7 +69,9 @@ var clientNodeServiceStartCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_service_start.go
+++ b/cmd/client_node_service_start.go
@@ -53,14 +53,14 @@ var clientNodeServiceStartCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeServiceStartCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_stop.go
+++ b/cmd/client_node_service_stop.go
@@ -53,14 +53,14 @@ var clientNodeServiceStopCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeServiceStopCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_stop.go
+++ b/cmd/client_node_service_stop.go
@@ -69,7 +69,9 @@ var clientNodeServiceStopCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_service_update.go
+++ b/cmd/client_node_service_update.go
@@ -57,14 +57,14 @@ var clientNodeServiceUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -72,8 +72,8 @@ var clientNodeServiceUpdateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_service_update.go
+++ b/cmd/client_node_service_update.go
@@ -73,7 +73,9 @@ var clientNodeServiceUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_status_get.go
+++ b/cmd/client_node_status_get.go
@@ -96,12 +96,12 @@ func displayNodeStatusCollection(
 			Fields:   []string{s.Uptime, load, memory},
 		})
 	}
-	headers, rows := cli.BuildBroadcastTable(results, []string{
+	tr := cli.BuildBroadcastTable(results, []string{
 		"UPTIME",
-		"LOAD (1m)",
-		"MEMORY USED",
+		"LOAD",
+		"MEM",
 	})
-	cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+	cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 }
 
 // displayNodeStatusDetail renders a single node status response with full details.

--- a/cmd/client_node_sysctl_create.go
+++ b/cmd/client_node_sysctl_create.go
@@ -58,14 +58,14 @@ var clientNodeSysctlCreateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -73,8 +73,8 @@ var clientNodeSysctlCreateCmd = &cobra.Command{
 				Fields:   []string{r.Key},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"KEY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"KEY"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_sysctl_create.go
+++ b/cmd/client_node_sysctl_create.go
@@ -74,7 +74,9 @@ var clientNodeSysctlCreateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"KEY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_sysctl_delete.go
+++ b/cmd/client_node_sysctl_delete.go
@@ -53,14 +53,14 @@ var clientNodeSysctlDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeSysctlDeleteCmd = &cobra.Command{
 				Fields:   []string{r.Key},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"KEY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"KEY"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_sysctl_delete.go
+++ b/cmd/client_node_sysctl_delete.go
@@ -69,7 +69,9 @@ var clientNodeSysctlDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"KEY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_sysctl_get.go
+++ b/cmd/client_node_sysctl_get.go
@@ -67,7 +67,9 @@ var clientNodeSysctlGetCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildBroadcastTable(results, []string{"KEY", "VALUE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_sysctl_get.go
+++ b/cmd/client_node_sysctl_get.go
@@ -66,8 +66,8 @@ var clientNodeSysctlGetCmd = &cobra.Command{
 				Fields:   []string{r.Key, r.Value},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{"KEY", "VALUE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildBroadcastTable(results, []string{"KEY", "VALUE"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_sysctl_list.go
+++ b/cmd/client_node_sysctl_list.go
@@ -65,8 +65,8 @@ var clientNodeSysctlListCmd = &cobra.Command{
 				Fields:   []string{r.Key, r.Value},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{"KEY", "VALUE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildBroadcastTable(results, []string{"KEY", "VALUE"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_sysctl_list.go
+++ b/cmd/client_node_sysctl_list.go
@@ -66,7 +66,9 @@ var clientNodeSysctlListCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildBroadcastTable(results, []string{"KEY", "VALUE"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_sysctl_update.go
+++ b/cmd/client_node_sysctl_update.go
@@ -57,14 +57,14 @@ var clientNodeSysctlUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -72,8 +72,8 @@ var clientNodeSysctlUpdateCmd = &cobra.Command{
 				Fields:   []string{r.Key},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"KEY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"KEY"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_sysctl_update.go
+++ b/cmd/client_node_sysctl_update.go
@@ -73,7 +73,9 @@ var clientNodeSysctlUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"KEY"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_timezone_get.go
+++ b/cmd/client_node_timezone_get.go
@@ -73,7 +73,9 @@ var clientNodeTimezoneGetCmd = &cobra.Command{
 			results,
 			[]string{"TIMEZONE", "UTC_OFFSET"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_timezone_get.go
+++ b/cmd/client_node_timezone_get.go
@@ -69,11 +69,11 @@ var clientNodeTimezoneGetCmd = &cobra.Command{
 				},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(
+		tr := cli.BuildBroadcastTable(
 			results,
 			[]string{"TIMEZONE", "UTC_OFFSET"},
 		)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_timezone_update.go
+++ b/cmd/client_node_timezone_update.go
@@ -71,7 +71,9 @@ var clientNodeTimezoneUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_timezone_update.go
+++ b/cmd/client_node_timezone_update.go
@@ -56,22 +56,22 @@ var clientNodeTimezoneUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
 				Error:    errPtr,
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, nil)
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, nil)
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_uptime_get.go
+++ b/cmd/client_node_uptime_get.go
@@ -67,7 +67,9 @@ var clientNodeUptimeGetCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildBroadcastTable(results, []string{"UPTIME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_uptime_get.go
+++ b/cmd/client_node_uptime_get.go
@@ -66,8 +66,8 @@ var clientNodeUptimeGetCmd = &cobra.Command{
 				Fields:   []string{r.Uptime},
 			})
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{"UPTIME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildBroadcastTable(results, []string{"UPTIME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_user_create.go
+++ b/cmd/client_node_user_create.go
@@ -70,14 +70,14 @@ var clientNodeUserCreateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -85,8 +85,8 @@ var clientNodeUserCreateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_user_create.go
+++ b/cmd/client_node_user_create.go
@@ -86,7 +86,9 @@ var clientNodeUserCreateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_user_delete.go
+++ b/cmd/client_node_user_delete.go
@@ -69,7 +69,9 @@ var clientNodeUserDeleteCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_user_delete.go
+++ b/cmd/client_node_user_delete.go
@@ -53,14 +53,14 @@ var clientNodeUserDeleteCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -68,8 +68,8 @@ var clientNodeUserDeleteCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_user_get.go
+++ b/cmd/client_node_user_get.go
@@ -85,7 +85,9 @@ var clientNodeUserGetCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "UID", "HOME", "SHELL", "GROUPS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_user_get.go
+++ b/cmd/client_node_user_get.go
@@ -69,29 +69,23 @@ var clientNodeUserGetCmd = &cobra.Command{
 				continue
 			}
 			for _, u := range r.Users {
-				locked := "no"
-				if u.Locked {
-					locked = "yes"
-				}
 				results = append(results, cli.ResultRow{
 					Hostname: r.Hostname,
 					Status:   r.Status,
 					Fields: []string{
 						u.Name,
 						fmt.Sprintf("%d", u.UID),
-						fmt.Sprintf("%d", u.GID),
 						u.Home,
 						u.Shell,
 						strings.Join(u.Groups, ","),
-						locked,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
-			"NAME", "UID", "GID", "HOME", "SHELL", "GROUPS", "LOCKED",
+		tr := cli.BuildBroadcastTable(results, []string{
+			"NAME", "UID", "HOME", "SHELL", "GROUPS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_user_list.go
+++ b/cmd/client_node_user_list.go
@@ -68,29 +68,23 @@ var clientNodeUserListCmd = &cobra.Command{
 				continue
 			}
 			for _, u := range r.Users {
-				locked := "no"
-				if u.Locked {
-					locked = "yes"
-				}
 				results = append(results, cli.ResultRow{
 					Hostname: r.Hostname,
 					Status:   r.Status,
 					Fields: []string{
 						u.Name,
 						fmt.Sprintf("%d", u.UID),
-						fmt.Sprintf("%d", u.GID),
 						u.Home,
 						u.Shell,
 						strings.Join(u.Groups, ","),
-						locked,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
-			"NAME", "UID", "GID", "HOME", "SHELL", "GROUPS", "LOCKED",
+		tr := cli.BuildBroadcastTable(results, []string{
+			"NAME", "UID", "HOME", "SHELL", "GROUPS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_user_list.go
+++ b/cmd/client_node_user_list.go
@@ -84,7 +84,9 @@ var clientNodeUserListCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"NAME", "UID", "HOME", "SHELL", "GROUPS",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_user_password.go
+++ b/cmd/client_node_user_password.go
@@ -54,14 +54,14 @@ var clientNodeUserPasswordCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -69,8 +69,8 @@ var clientNodeUserPasswordCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_user_password.go
+++ b/cmd/client_node_user_password.go
@@ -70,7 +70,9 @@ var clientNodeUserPasswordCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_user_ssh_key_add.go
+++ b/cmd/client_node_user_ssh_key_add.go
@@ -55,14 +55,14 @@ var clientNodeUserSSHKeyAddCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -70,8 +70,8 @@ var clientNodeUserSSHKeyAddCmd = &cobra.Command{
 				Fields:   []string{fmt.Sprintf("%t", r.Changed)},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"CHANGED"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"CHANGED"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_user_ssh_key_add.go
+++ b/cmd/client_node_user_ssh_key_add.go
@@ -71,7 +71,9 @@ var clientNodeUserSSHKeyAddCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"CHANGED"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_user_ssh_key_list.go
+++ b/cmd/client_node_user_ssh_key_list.go
@@ -81,7 +81,9 @@ var clientNodeUserSSHKeyListCmd = &cobra.Command{
 		tr := cli.BuildBroadcastTable(results, []string{
 			"TYPE", "FINGERPRINT",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_user_ssh_key_list.go
+++ b/cmd/client_node_user_ssh_key_list.go
@@ -74,15 +74,14 @@ var clientNodeUserSSHKeyListCmd = &cobra.Command{
 					Fields: []string{
 						k.Type,
 						k.Fingerprint,
-						k.Comment,
 					},
 				})
 			}
 		}
-		headers, rows := cli.BuildBroadcastTable(results, []string{
-			"TYPE", "FINGERPRINT", "COMMENT",
+		tr := cli.BuildBroadcastTable(results, []string{
+			"TYPE", "FINGERPRINT",
 		})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_user_ssh_key_remove.go
+++ b/cmd/client_node_user_ssh_key_remove.go
@@ -70,7 +70,9 @@ var clientNodeUserSSHKeyRemoveCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"CHANGED"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_user_ssh_key_remove.go
+++ b/cmd/client_node_user_ssh_key_remove.go
@@ -54,14 +54,14 @@ var clientNodeUserSSHKeyRemoveCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -69,8 +69,8 @@ var clientNodeUserSSHKeyRemoveCmd = &cobra.Command{
 				Fields:   []string{fmt.Sprintf("%t", r.Changed)},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"CHANGED"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"CHANGED"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/cmd/client_node_user_update.go
+++ b/cmd/client_node_user_update.go
@@ -91,7 +91,9 @@ var clientNodeUserUpdateCmd = &cobra.Command{
 			})
 		}
 		tr := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
+		cli.PrintCompactTable(
+			[]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}},
+		)
 	},
 }
 

--- a/cmd/client_node_user_update.go
+++ b/cmd/client_node_user_update.go
@@ -75,14 +75,14 @@ var clientNodeUserUpdateCmd = &cobra.Command{
 			cli.PrintKV("Job ID", resp.Data.JobID)
 		}
 
-		results := make([]cli.MutationResultRow, 0, len(resp.Data.Results))
+		results := make([]cli.ResultRow, 0, len(resp.Data.Results))
 		for _, r := range resp.Data.Results {
 			var errPtr *string
 			if r.Error != "" {
 				errPtr = &r.Error
 			}
 			changed := r.Changed
-			results = append(results, cli.MutationResultRow{
+			results = append(results, cli.ResultRow{
 				Hostname: r.Hostname,
 				Status:   r.Status,
 				Changed:  &changed,
@@ -90,8 +90,8 @@ var clientNodeUserUpdateCmd = &cobra.Command{
 				Fields:   []string{r.Name},
 			})
 		}
-		headers, rows := cli.BuildMutationTable(results, []string{"NAME"})
-		cli.PrintCompactTable([]cli.Section{{Headers: headers, Rows: rows}})
+		tr := cli.BuildMutationTable(results, []string{"NAME"})
+		cli.PrintCompactTable([]cli.Section{{Headers: tr.Headers, Rows: tr.Rows, Errors: tr.Errors}})
 	},
 }
 

--- a/docs/docs/sidebar/usage/cli/client/node/certificate/create.md
+++ b/docs/docs/sidebar/usage/cli/client/node/certificate/create.md
@@ -12,8 +12,10 @@ $ osapi client node certificate create --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME         CHANGED
-  web-01    internal-ca  true
+  HOSTNAME  STATUS   NAME         CHANGED
+  web-01    changed  internal-ca  true
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts at once:
@@ -24,13 +26,14 @@ $ osapi client node certificate create --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME         CHANGED
-  web-01    internal-ca  true
-  web-02    internal-ca  true
+  HOSTNAME  STATUS   NAME         CHANGED
+  web-01    changed  internal-ca  true
+  web-02    changed  internal-ca  true
+
+  2 hosts: 2 changed
 ```
 
-When some hosts are skipped (e.g., macOS agents), STATUS and ERROR columns are
-added:
+When some hosts are skipped (e.g., macOS agents):
 
 ```bash
 $ osapi client node certificate create --target _all \
@@ -38,9 +41,14 @@ $ osapi client node certificate create --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   NAME         CHANGED  ERROR
-  web-01    ok       internal-ca  true
-  mac-01    skipped                        unsupported platform
+  HOSTNAME  STATUS   NAME         CHANGED
+  web-01    changed  internal-ca  true
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/certificate/delete.md
+++ b/docs/docs/sidebar/usage/cli/client/node/certificate/delete.md
@@ -10,8 +10,10 @@ $ osapi client node certificate delete --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME         CHANGED
-  web-01    internal-ca  true
+  HOSTNAME  STATUS   NAME         CHANGED
+  web-01    changed  internal-ca  true
+
+  1 host: 1 changed
 ```
 
 If the certificate does not exist, `changed: false` is returned:
@@ -22,8 +24,10 @@ $ osapi client node certificate delete --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME         CHANGED
-  web-01    internal-ca  false
+  HOSTNAME  STATUS  NAME         CHANGED
+  web-01    ok      internal-ca  false
+
+  1 host: 1 ok
 ```
 
 Broadcast to all hosts:
@@ -34,9 +38,11 @@ $ osapi client node certificate delete --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME         CHANGED
-  web-01    internal-ca  true
-  web-02    internal-ca  true
+  HOSTNAME  STATUS   NAME         CHANGED
+  web-01    changed  internal-ca  true
+  web-02    changed  internal-ca  true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/certificate/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/certificate/list.md
@@ -8,10 +8,12 @@ $ osapi client node certificate list --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME                    SOURCE
-  web-01    mozilla/DigiCert.crt    system
-  web-01    mozilla/GlobalSign.crt  system
-  web-01    internal-ca             custom
+  HOSTNAME  STATUS  NAME                    SOURCE
+  web-01    ok      mozilla/DigiCert.crt    system
+  web-01    ok      mozilla/GlobalSign.crt  system
+  web-01    ok      internal-ca             custom
+
+  1 host: 1 ok
 ```
 
 Target all hosts to list certificates across the fleet:
@@ -21,12 +23,14 @@ $ osapi client node certificate list --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME                    SOURCE
-  web-01    mozilla/DigiCert.crt    system
-  web-01    mozilla/GlobalSign.crt  system
-  web-01    internal-ca             custom
-  web-02    mozilla/DigiCert.crt    system
-  web-02    mozilla/GlobalSign.crt  system
+  HOSTNAME  STATUS  NAME                    SOURCE
+  web-01    ok      mozilla/DigiCert.crt    system
+  web-01    ok      mozilla/GlobalSign.crt  system
+  web-01    ok      internal-ca             custom
+  web-02    ok      mozilla/DigiCert.crt    system
+  web-02    ok      mozilla/GlobalSign.crt  system
+
+  2 hosts: 2 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/certificate/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/certificate/update.md
@@ -11,8 +11,10 @@ $ osapi client node certificate update --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME         CHANGED
-  web-01    internal-ca  true
+  HOSTNAME  STATUS   NAME         CHANGED
+  web-01    changed  internal-ca  true
+
+  1 host: 1 changed
 ```
 
 If the content has not changed (same SHA), `changed: false` is returned:
@@ -23,8 +25,10 @@ $ osapi client node certificate update --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME         CHANGED
-  web-01    internal-ca  false
+  HOSTNAME  STATUS  NAME         CHANGED
+  web-01    ok      internal-ca  false
+
+  1 host: 1 ok
 ```
 
 Broadcast to all hosts at once:
@@ -35,9 +39,11 @@ $ osapi client node certificate update --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME         CHANGED
-  web-01    internal-ca  true
-  web-02    internal-ca  true
+  HOSTNAME  STATUS   NAME         CHANGED
+  web-01    changed  internal-ca  true
+  web-02    changed  internal-ca  true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/command/exec.md
+++ b/docs/docs/sidebar/usage/cli/client/node/command/exec.md
@@ -8,8 +8,10 @@ $ osapi client node command exec --command ls --args "-la,/tmp"
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  CHANGED  STDOUT                          STDERR  EXIT CODE  DURATION
-  web-01    false    total 8 drwxrwxrwt 10 root r…           0          12ms
+  HOSTNAME  STATUS  EXIT  STDOUT
+  web-01    ok      0     total 8 drwxrwxrwt 10 root r...
+
+  1 host: 1 ok
 ```
 
 Long output is truncated in the table view. Use `--json` for the full response

--- a/docs/docs/sidebar/usage/cli/client/node/command/shell.md
+++ b/docs/docs/sidebar/usage/cli/client/node/command/shell.md
@@ -8,8 +8,10 @@ $ osapi client node command shell --command "ls -la /tmp | grep log"
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  CHANGED  STDOUT                          STDERR  EXIT CODE  DURATION
-  web-01    false    -rw-r--r-- 1 root root 4096 …           0          15ms
+  HOSTNAME  STATUS  EXIT  STDOUT
+  web-01    ok      0     -rw-r--r-- 1 root root 4096 ...
+
+  1 host: 1 ok
 ```
 
 Long output is truncated in the table view. Use `--json` for the full response

--- a/docs/docs/sidebar/usage/cli/client/node/container/docker/create.md
+++ b/docs/docs/sidebar/usage/cli/client/node/container/docker/create.md
@@ -7,8 +7,10 @@ $ osapi client node container docker create --image nginx:latest
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  ID            NAME          IMAGE         STATE
-  server1   ok      true            a1b2c3d4e5f6  eager_turing  nginx:latest  running
+  HOSTNAME  STATUS   CHANGED  NAME          IMAGE         STATE
+  server1   changed  true     eager_turing  nginx:latest  running
+
+  1 host: 1 changed
 ```
 
 Create a named container with environment variables, port mappings, and volume

--- a/docs/docs/sidebar/usage/cli/client/node/container/docker/exec.md
+++ b/docs/docs/sidebar/usage/cli/client/node/container/docker/exec.md
@@ -7,8 +7,10 @@ $ osapi client node container docker exec --id my-nginx --command "ls,-la,/"
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  EXIT CODE  STDOUT     STDERR
-  server1   0          total 80…
+  HOSTNAME  STATUS  EXIT  STDOUT
+  server1   ok      0     total 80...
+
+  1 host: 1 ok
 ```
 
 Execute with environment variables and a working directory:

--- a/docs/docs/sidebar/usage/cli/client/node/container/docker/image-remove.md
+++ b/docs/docs/sidebar/usage/cli/client/node/container/docker/image-remove.md
@@ -7,8 +7,10 @@ $ osapi client node container docker image-remove --image nginx:latest
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  MESSAGE
-  server1   ok      true            Image removed successfully
+  HOSTNAME  STATUS   CHANGED  MESSAGE
+  server1   changed  true     Image removed successfully
+
+  1 host: 1 changed
 ```
 
 Force remove an image that may be in use:

--- a/docs/docs/sidebar/usage/cli/client/node/container/docker/inspect.md
+++ b/docs/docs/sidebar/usage/cli/client/node/container/docker/inspect.md
@@ -7,8 +7,10 @@ $ osapi client node container docker inspect --id a1b2c3d4e5f6
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  ID            NAME      IMAGE         STATE    CREATED               HEALTH   PORTS             MOUNTS             NETWORK
-  server1   a1b2c3d4e5f6  my-nginx  nginx:latest  running  2024-01-15T10:30:00Z           8080:80,8443:443  /data:/var/lib/data  172.17.0.2
+  HOSTNAME  STATUS  NAME      IMAGE         STATE    PORTS             MOUNTS              NETWORK
+  server1   ok      my-nginx  nginx:latest  running  8080:80,8443:443  /data:/var/lib/data  172.17.0.2
+
+  1 host: 1 ok
 ```
 
 Inspect a container by name:

--- a/docs/docs/sidebar/usage/cli/client/node/container/docker/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/container/docker/list.md
@@ -7,10 +7,12 @@ $ osapi client node container docker list
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  ID            NAME        IMAGE          STATE    CREATED
-  server1   a1b2c3d4e5f6  my-nginx    nginx:latest   running  2024-01-15T10:30:00Z
-  server1   f6e5d4c3b2a1  my-redis    redis:7        running  2024-01-15T09:00:00Z
-  server1   1a2b3c4d5e6f  my-alpine   alpine:latest  stopped  2024-01-14T08:00:00Z
+  HOSTNAME  STATUS  NAME        IMAGE          STATE
+  server1   ok      my-nginx    nginx:latest   running
+  server1   ok      my-redis    redis:7        running
+  server1   ok      my-alpine   alpine:latest  stopped
+
+  1 host: 1 ok
 ```
 
 Filter by state:

--- a/docs/docs/sidebar/usage/cli/client/node/container/docker/pull.md
+++ b/docs/docs/sidebar/usage/cli/client/node/container/docker/pull.md
@@ -7,8 +7,10 @@ $ osapi client node container docker pull --image nginx:latest
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  IMAGE ID            TAG     SIZE
-  server1   ok      true            sha256:a1b2c3d4...  latest  187.8 MiB
+  HOSTNAME  STATUS   CHANGED  IMAGE ID            TAG     SIZE
+  server1   changed  true     sha256:a1b2c3d4...  latest  187.8 MiB
+
+  1 host: 1 changed
 ```
 
 Pull a specific image version:

--- a/docs/docs/sidebar/usage/cli/client/node/container/docker/remove.md
+++ b/docs/docs/sidebar/usage/cli/client/node/container/docker/remove.md
@@ -7,8 +7,10 @@ $ osapi client node container docker remove --id a1b2c3d4e5f6
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  MESSAGE
-  server1   ok      true            container removed
+  HOSTNAME  STATUS   CHANGED  MESSAGE
+  server1   changed  true     container removed
+
+  1 host: 1 changed
 ```
 
 Force removal of a running container:

--- a/docs/docs/sidebar/usage/cli/client/node/container/docker/start.md
+++ b/docs/docs/sidebar/usage/cli/client/node/container/docker/start.md
@@ -7,8 +7,10 @@ $ osapi client node container docker start --id a1b2c3d4e5f6
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  MESSAGE
-  server1   ok      true            container started
+  HOSTNAME  STATUS   CHANGED  MESSAGE
+  server1   changed  true     container started
+
+  1 host: 1 changed
 ```
 
 Start a container by name:

--- a/docs/docs/sidebar/usage/cli/client/node/container/docker/stop.md
+++ b/docs/docs/sidebar/usage/cli/client/node/container/docker/stop.md
@@ -7,8 +7,10 @@ $ osapi client node container docker stop --id a1b2c3d4e5f6
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  MESSAGE
-  server1   ok      true            container stopped
+  HOSTNAME  STATUS   CHANGED  MESSAGE
+  server1   changed  true     container stopped
+
+  1 host: 1 changed
 ```
 
 Stop with a custom timeout (seconds to wait before killing):

--- a/docs/docs/sidebar/usage/cli/client/node/disk/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/disk/get.md
@@ -7,23 +7,27 @@ $ osapi client node disk get
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  MOUNT  TOTAL   USED    FREE    USAGE
-  web-01    /      97 GB   56 GB   36 GB   58%
-  web-01    /boot  1 GB    0 GB    1 GB    0%
-  web-01    /home  450 GB  120 GB  310 GB  27%
+  HOSTNAME  STATUS  MOUNT  TOTAL   USED    USAGE
+  web-01    ok      /      97 GB   56 GB   58%
+  web-01    ok      /boot  1 GB    0 GB    0%
+  web-01    ok      /home  450 GB  120 GB  27%
+
+  1 host: 1 ok
 ```
 
-When targeting all hosts, the HOSTNAME column is shown:
+When targeting all hosts:
 
 ```bash
 $ osapi client node disk get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  MOUNT  TOTAL   USED   FREE    USAGE
-  server1   /      97 GB   56 GB  36 GB   58%
-  server1   /boot  1 GB    0 GB   1 GB    0%
-  server2   /      200 GB  80 GB  110 GB  40%
+  HOSTNAME  STATUS  MOUNT  TOTAL   USED   USAGE
+  server1   ok      /      97 GB   56 GB  58%
+  server1   ok      /boot  1 GB    0 GB   0%
+  server2   ok      /      200 GB  80 GB  40%
+
+  2 hosts: 2 ok
 ```
 
 Target by label to query a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/file/deploy.md
+++ b/docs/docs/sidebar/usage/cli/client/node/file/deploy.md
@@ -6,10 +6,12 @@ idempotency ensures unchanged files are not rewritten.
 ```bash
 $ osapi client node file deploy --object app.conf --path /etc/app/app.conf
 
-  Job ID:   550e8400-e29b-41d4-a716-446655440000
-  Hostname: server1
-  Status:   ok
-  Changed:  true
+  Job ID: 550e8400-e29b-41d4-a716-446655440000
+
+  HOSTNAME  STATUS   CHANGED
+  server1   changed  true
+
+  1 host: 1 changed
 ```
 
 Deploy with file permissions:

--- a/docs/docs/sidebar/usage/cli/client/node/file/status.md
+++ b/docs/docs/sidebar/usage/cli/client/node/file/status.md
@@ -6,11 +6,12 @@ file is `in-sync`, `drifted`, or `missing`.
 ```bash
 $ osapi client node file status --path /etc/app/app.conf
 
-  Job ID:   550e8400-e29b-41d4-a716-446655440000
-  Hostname: server1
-  Path:     /etc/app/app.conf
-  Status:   in-sync
-  SHA256:   a1b2c3d4e5f6...
+  Job ID: 550e8400-e29b-41d4-a716-446655440000
+
+  HOSTNAME  STATUS  PATH               FILE STATUS  SHA256
+  server1   ok      /etc/app/app.conf  in-sync      a1b2c3d4e5f6...
+
+  1 host: 1 ok
 ```
 
 When a file has been modified on disk:
@@ -18,11 +19,12 @@ When a file has been modified on disk:
 ```bash
 $ osapi client node file status --path /etc/app/app.conf
 
-  Job ID:   550e8400-e29b-41d4-a716-446655440000
-  Hostname: server1
-  Path:     /etc/app/app.conf
-  Status:   drifted
-  SHA256:   9f8e7d6c5b4a...
+  Job ID: 550e8400-e29b-41d4-a716-446655440000
+
+  HOSTNAME  STATUS  PATH               FILE STATUS  SHA256
+  server1   ok      /etc/app/app.conf  drifted      9f8e7d6c5b4a...
+
+  1 host: 1 ok
 ```
 
 When a file has not been deployed or was deleted:
@@ -30,10 +32,12 @@ When a file has not been deployed or was deleted:
 ```bash
 $ osapi client node file status --path /etc/app/app.conf
 
-  Job ID:   550e8400-e29b-41d4-a716-446655440000
-  Hostname: server1
-  Path:     /etc/app/app.conf
-  Status:   missing
+  Job ID: 550e8400-e29b-41d4-a716-446655440000
+
+  HOSTNAME  STATUS  PATH               FILE STATUS
+  server1   ok      /etc/app/app.conf  missing
+
+  1 host: 1 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/file/undeploy.md
+++ b/docs/docs/sidebar/usage/cli/client/node/file/undeploy.md
@@ -8,9 +8,12 @@ $ osapi client node file undeploy \
     --target server1 \
     --path /etc/app/app.conf
 
-  Hostname: server1
-  Status:   ok
-  Changed:  true
+  Job ID: 550e8400-e29b-41d4-a716-446655440000
+
+  HOSTNAME  STATUS   CHANGED
+  server1   changed  true
+
+  1 host: 1 changed
 ```
 
 If the file does not exist on disk, the operation is a no-op and

--- a/docs/docs/sidebar/usage/cli/client/node/group/create.md
+++ b/docs/docs/sidebar/usage/cli/client/node/group/create.md
@@ -5,8 +5,10 @@ Create a new group:
 ```bash
 $ osapi client node group create --target web-01 --name deploy
 
-  HOSTNAME  NAME     CHANGED  STATUS
-  web-01    deploy   true     ok
+  HOSTNAME  STATUS   NAME     CHANGED
+  web-01    changed  deploy   true
+
+  1 host: 1 changed
 ```
 
 ## Flags

--- a/docs/docs/sidebar/usage/cli/client/node/group/delete.md
+++ b/docs/docs/sidebar/usage/cli/client/node/group/delete.md
@@ -5,8 +5,10 @@ Delete a group:
 ```bash
 $ osapi client node group delete --target web-01 --name deploy
 
-  HOSTNAME  NAME     CHANGED  STATUS
-  web-01    deploy   true     ok
+  HOSTNAME  STATUS   NAME     CHANGED
+  web-01    changed  deploy   true
+
+  1 host: 1 changed
 ```
 
 ## Flags

--- a/docs/docs/sidebar/usage/cli/client/node/group/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/group/get.md
@@ -5,8 +5,10 @@ Get a specific group by name:
 ```bash
 $ osapi client node group get --target web-01 --name docker
 
-  HOSTNAME  NAME     GID   MEMBERS
-  web-01    docker   999   deploy,app
+  HOSTNAME  STATUS  NAME     GID   MEMBERS
+  web-01    ok      docker   999   deploy,app
+
+  1 host: 1 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/group/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/group/list.md
@@ -5,10 +5,12 @@ List all groups on a target host:
 ```bash
 $ osapi client node group list --target web-01
 
-  HOSTNAME  NAME     GID   MEMBERS
-  web-01    docker   999   deploy,app
-  web-01    sudo     27    deploy
-  web-01    users    100   deploy,app
+  HOSTNAME  STATUS  NAME     GID   MEMBERS
+  web-01    ok      docker   999   deploy,app
+  web-01    ok      sudo     27    deploy
+  web-01    ok      users    100   deploy,app
+
+  1 host: 1 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/group/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/group/update.md
@@ -6,8 +6,10 @@ Update a group's member list:
 $ osapi client node group update --target web-01 \
     --name deploy --members alice,bob
 
-  HOSTNAME  NAME     CHANGED  STATUS
-  web-01    deploy   true     ok
+  HOSTNAME  STATUS   NAME     CHANGED
+  web-01    changed  deploy   true
+
+  1 host: 1 changed
 ```
 
 The `--members` flag replaces the existing member list entirely.

--- a/docs/docs/sidebar/usage/cli/client/node/hostname/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/hostname/get.md
@@ -7,8 +7,10 @@ $ osapi client node hostname get
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  LABELS
-  web-01    group:web
+  HOSTNAME  STATUS
+  web-01    ok
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -21,6 +23,8 @@ $ osapi client node hostname get --target _all
   HOSTNAME  STATUS
   server1   ok
   server2   ok
+
+  2 hosts: 2 ok
 ```
 
 When some hosts fail or are skipped:
@@ -30,9 +34,14 @@ $ osapi client node hostname get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   ERROR
+  HOSTNAME  STATUS
   server1   ok
-  server2   skipped  unsupported platform
+  server2   skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 When a single host does not support the operation:
@@ -42,8 +51,13 @@ $ osapi client node hostname get --target darwin-host
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME     STATUS   ERROR
-  darwin-host  skipped  host: operation not supported on this OS family
+  HOSTNAME     STATUS
+  darwin-host  skip
+
+  1 host: 1 skipped
+
+  Details:
+  darwin-host  host: operation not supported on this OS family
 ```
 
 Target by label to query a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/hostname/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/hostname/update.md
@@ -7,8 +7,10 @@ $ osapi client node hostname update --name web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
-  web-01    ok      true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
 When the target host does not support the operation:
@@ -18,8 +20,13 @@ $ osapi client node hostname update --name web-01 --target darwin-host
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME     STATUS   CHANGED  ERROR
-  darwin-host  skipped           host: operation not supported on this OS family
+  HOSTNAME     STATUS
+  darwin-host  skip
+
+  1 host: 1 skipped
+
+  Details:
+  darwin-host  host: operation not supported on this OS family
 ```
 
 When targeting all hosts:
@@ -29,9 +36,14 @@ $ osapi client node hostname update --name web-01 --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR
-  server1   ok       true
-  server2   skipped           unsupported platform
+  HOSTNAME  STATUS   CHANGED
+  server1   changed  true
+  server2   skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 ## Flags

--- a/docs/docs/sidebar/usage/cli/client/node/load/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/load/get.md
@@ -7,8 +7,10 @@ $ osapi client node load get
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  LOAD (1m)  LOAD (5m)  LOAD (15m)
-  web-01    1.83       1.96       2.02
+  HOSTNAME  STATUS  LOAD (1m)  LOAD (5m)  LOAD (15m)
+  web-01    ok      1.83       1.96       2.02
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -18,9 +20,11 @@ $ osapi client node load get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  LOAD (1m)  LOAD (5m)  LOAD (15m)
-  server1   1.83       1.96       2.02
-  server2   0.45       0.52       0.61
+  HOSTNAME  STATUS  LOAD (1m)  LOAD (5m)  LOAD (15m)
+  server1   ok      1.83       1.96       2.02
+  server2   ok      0.45       0.52       0.61
+
+  2 hosts: 2 ok
 ```
 
 When some hosts fail or are skipped:
@@ -30,9 +34,14 @@ $ osapi client node load get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   LOAD (1m)  LOAD (5m)  LOAD (15m)  ERROR
-  server1   ok       1.83       1.96       2.02
-  server2   skipped                                     unsupported platform
+  HOSTNAME  STATUS  LOAD (1m)  LOAD (5m)  LOAD (15m)
+  server1   ok      1.83       1.96       2.02
+  server2   skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 Target by label to query a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/log/query.md
+++ b/docs/docs/sidebar/usage/cli/client/node/log/query.md
@@ -7,10 +7,12 @@ $ osapi client node log query --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  TIMESTAMP                  PRIORITY  UNIT           MESSAGE
-  web-01    2026-01-01T00:00:01+00:00  info      sshd.service   Accepted publickey for ...
-  web-01    2026-01-01T00:00:02+00:00  notice    kernel         Linux version 6.1.0 ...
-  web-01    2026-01-01T00:00:03+00:00  err       nginx.service  connect() failed (111...
+  HOSTNAME  STATUS  TIMESTAMP                  UNIT           MESSAGE
+  web-01    ok      2026-01-01T00:00:01+00:00  sshd.service   Accepted publickey for ...
+  web-01    ok      2026-01-01T00:00:02+00:00  kernel         Linux version 6.1.0 ...
+  web-01    ok      2026-01-01T00:00:03+00:00  nginx.service  connect() failed (111...
+
+  1 host: 1 ok
 ```
 
 Filter by priority and time window:
@@ -21,8 +23,10 @@ $ osapi client node log query --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  TIMESTAMP                  PRIORITY  UNIT           MESSAGE
-  web-01    2026-01-01T00:59:01+00:00  err       nginx.service  connect() failed (111...
+  HOSTNAME  STATUS  TIMESTAMP                  UNIT           MESSAGE
+  web-01    ok      2026-01-01T00:59:01+00:00  nginx.service  connect() failed (111...
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -32,22 +36,28 @@ $ osapi client node log query --target _all --lines 5
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  TIMESTAMP                  PRIORITY  UNIT           MESSAGE
-  web-01    2026-01-01T00:00:01+00:00  info      sshd.service   Accepted publickey for ...
-  web-02    2026-01-01T00:00:02+00:00  notice    kernel         Linux version 6.1.0 ...
+  HOSTNAME  STATUS  TIMESTAMP                  UNIT           MESSAGE
+  web-01    ok      2026-01-01T00:00:01+00:00  sshd.service   Accepted publickey for ...
+  web-02    ok      2026-01-01T00:00:02+00:00  kernel         Linux version 6.1.0 ...
+
+  2 hosts: 2 ok
 ```
 
-When some hosts are skipped, STATUS and ERROR columns appear alongside data
-columns:
+When some hosts are skipped:
 
 ```bash
 $ osapi client node log query --target _all --lines 5
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   ERROR                 TIMESTAMP                  PRIORITY  UNIT           MESSAGE
-  web-01    ok                              2026-01-01T00:00:01+00:00  info      sshd.service   Accepted publickey for ...
-  mac-01    skipped  unsupported platform
+  HOSTNAME  STATUS  TIMESTAMP                  UNIT           MESSAGE
+  web-01    ok      2026-01-01T00:00:01+00:00  sshd.service   Accepted publickey for ...
+  mac-01    skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/log/source.md
+++ b/docs/docs/sidebar/usage/cli/client/node/log/source.md
@@ -7,12 +7,14 @@ $ osapi client node log source --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  SOURCE
-  web-01    cron
-  web-01    kernel
-  web-01    nginx
-  web-01    sshd
-  web-01    systemd
+  HOSTNAME  STATUS  SOURCE
+  web-01    ok      cron
+  web-01    ok      kernel
+  web-01    ok      nginx
+  web-01    ok      sshd
+  web-01    ok      systemd
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -22,13 +24,15 @@ $ osapi client node log source --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  SOURCE
-  web-01    cron
-  web-01    kernel
-  web-01    nginx
-  web-01    sshd
-  web-02    kernel
-  web-02    systemd
+  HOSTNAME  STATUS  SOURCE
+  web-01    ok      cron
+  web-01    ok      kernel
+  web-01    ok      nginx
+  web-01    ok      sshd
+  web-02    ok      kernel
+  web-02    ok      systemd
+
+  2 hosts: 2 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/log/unit.md
+++ b/docs/docs/sidebar/usage/cli/client/node/log/unit.md
@@ -7,10 +7,12 @@ $ osapi client node log unit --target web-01 --name sshd.service
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  TIMESTAMP                  PRIORITY  UNIT          MESSAGE
-  web-01    2026-01-01T00:00:01+00:00  info      sshd.service  Accepted publickey for ...
-  web-01    2026-01-01T00:00:02+00:00  info      sshd.service  pam_unix(sshd:session): ...
-  web-01    2026-01-01T00:00:03+00:00  info      sshd.service  Disconnected from user ...
+  HOSTNAME  STATUS  TIMESTAMP                  UNIT          MESSAGE
+  web-01    ok      2026-01-01T00:00:01+00:00  sshd.service  Accepted publickey for ...
+  web-01    ok      2026-01-01T00:00:02+00:00  sshd.service  pam_unix(sshd:session): ...
+  web-01    ok      2026-01-01T00:00:03+00:00  sshd.service  Disconnected from user ...
+
+  1 host: 1 ok
 ```
 
 Filter to recent errors only:
@@ -21,8 +23,10 @@ $ osapi client node log unit --target web-01 --name nginx.service \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  TIMESTAMP                  PRIORITY  UNIT           MESSAGE
-  web-01    2026-01-01T00:31:15+00:00  err       nginx.service  connect() failed (111...
+  HOSTNAME  STATUS  TIMESTAMP                  UNIT           MESSAGE
+  web-01    ok      2026-01-01T00:31:15+00:00  nginx.service  connect() failed (111...
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -32,9 +36,11 @@ $ osapi client node log unit --target _all --name sshd.service --lines 5
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  TIMESTAMP                  PRIORITY  UNIT          MESSAGE
-  web-01    2026-01-01T00:00:01+00:00  info      sshd.service  Accepted publickey for ...
-  web-02    2026-01-01T00:00:02+00:00  info      sshd.service  Accepted publickey for ...
+  HOSTNAME  STATUS  TIMESTAMP                  UNIT          MESSAGE
+  web-01    ok      2026-01-01T00:00:01+00:00  sshd.service  Accepted publickey for ...
+  web-02    ok      2026-01-01T00:00:02+00:00  sshd.service  Accepted publickey for ...
+
+  2 hosts: 2 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/memory/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/memory/get.md
@@ -7,8 +7,10 @@ $ osapi client node memory get
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  MEMORY
-  web-01    19 GB used / 31 GB total / 10 GB free
+  HOSTNAME  STATUS  MEMORY
+  web-01    ok      19 GB used / 31 GB total / 10 GB free
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -18,9 +20,11 @@ $ osapi client node memory get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  MEMORY
-  server1   19 GB used / 31 GB total / 10 GB free
-  server2   8 GB used / 16 GB total / 7 GB free
+  HOSTNAME  STATUS  MEMORY
+  server1   ok      19 GB used / 31 GB total / 10 GB free
+  server2   ok      8 GB used / 16 GB total / 7 GB free
+
+  2 hosts: 2 ok
 ```
 
 When some hosts fail or are skipped:
@@ -30,9 +34,14 @@ $ osapi client node memory get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   MEMORY                               ERROR
-  server1   ok       19 GB used / 31 GB total / 10 GB free
-  server2   skipped                                       unsupported platform
+  HOSTNAME  STATUS  MEMORY
+  server1   ok      19 GB used / 31 GB total / 10 GB free
+  server2   skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 Target by label to query a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/network/dns/delete.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/dns/delete.md
@@ -9,12 +9,13 @@ $ osapi client node network dns delete \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
-  web-01    ok      true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
-When targeting all hosts, HOSTNAME is shown. STATUS and ERROR columns appear
-when any host has an error or is skipped:
+When targeting all hosts:
 
 ```bash
 $ osapi client node network dns delete \
@@ -23,9 +24,14 @@ $ osapi client node network dns delete \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR
-  server1   ok       true
-  server2   skipped           unsupported platform
+  HOSTNAME  STATUS   CHANGED
+  server1   changed  true
+  server2   skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 Returns `changed: false` if no OSAPI-managed DNS configuration exists for the

--- a/docs/docs/sidebar/usage/cli/client/node/network/dns/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/dns/get.md
@@ -7,8 +7,10 @@ $ osapi client node network dns get --interface-name eth0
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  SERVERS                              SEARCH DOMAINS
-  web-01    192.168.0.247, 2607:f428::1          example.com
+  HOSTNAME  STATUS  SERVERS                              SEARCH DOMAINS
+  web-01    ok      192.168.0.247, 2607:f428::1          example.com
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -18,21 +20,28 @@ $ osapi client node network dns get --interface-name eth0 --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  SERVERS                      SEARCH DOMAINS
-  server1   192.168.0.247, 2607:f428::1  example.com
-  server2   8.8.8.8, 1.1.1.1             local
+  HOSTNAME  STATUS  SERVERS                      SEARCH DOMAINS
+  server1   ok      192.168.0.247, 2607:f428::1  example.com
+  server2   ok      8.8.8.8, 1.1.1.1             local
+
+  2 hosts: 2 ok
 ```
 
-When some hosts fail or are skipped, STATUS and ERROR columns are shown:
+When some hosts fail or are skipped:
 
 ```bash
 $ osapi client node network dns get --interface-name eth0 --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   SERVERS                      SEARCH DOMAINS  ERROR
-  server1   ok       192.168.0.247, 2607:f428::1  example.com
-  server2   skipped                                               unsupported platform
+  HOSTNAME  STATUS  SERVERS                      SEARCH DOMAINS
+  server1   ok      192.168.0.247, 2607:f428::1  example.com
+  server2   skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 Target by label to query a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/network/dns/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/dns/update.md
@@ -10,12 +10,13 @@ $ osapi client node network dns update \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
-  web-01    ok      true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
-When targeting all hosts, HOSTNAME is shown. STATUS and ERROR columns appear
-when any host has an error or is skipped:
+When targeting all hosts:
 
 ```bash
 $ osapi client node network dns update \
@@ -25,9 +26,14 @@ $ osapi client node network dns update \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR
-  server1   ok       true
-  server2   skipped           unsupported platform
+  HOSTNAME  STATUS   CHANGED
+  server1   changed  true
+  server2   skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 Target by label to update a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/network/interface/create.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/interface/create.md
@@ -12,8 +12,10 @@ $ osapi client node network interface create \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CHANGED
-  web-01    eth0    true
+  HOSTNAME  STATUS   NAME    CHANGED
+  web-01    changed  eth0    true
+
+  1 host: 1 changed
 ```
 
 Create an interface with DHCP:
@@ -24,8 +26,10 @@ $ osapi client node network interface create \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CHANGED
-  web-01    eth1    true
+  HOSTNAME  STATUS   NAME    CHANGED
+  web-01    changed  eth1    true
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts at once:
@@ -36,13 +40,14 @@ $ osapi client node network interface create \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CHANGED
-  web-01    eth1    true
-  web-02    eth1    true
+  HOSTNAME  STATUS   NAME    CHANGED
+  web-01    changed  eth1    true
+  web-02    changed  eth1    true
+
+  2 hosts: 2 changed
 ```
 
-When some hosts are skipped (e.g., macOS agents), STATUS and ERROR columns are
-added:
+When some hosts are skipped (e.g., macOS agents):
 
 ```bash
 $ osapi client node network interface create \
@@ -50,9 +55,14 @@ $ osapi client node network interface create \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   NAME    CHANGED  ERROR
-  web-01    ok       eth1    true
-  mac-01    skipped                   unsupported platform
+  HOSTNAME  STATUS   NAME    CHANGED
+  web-01    changed  eth1    true
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/network/interface/delete.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/interface/delete.md
@@ -9,8 +9,10 @@ $ osapi client node network interface delete \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CHANGED
-  web-01    eth0    true
+  HOSTNAME  STATUS   NAME    CHANGED
+  web-01    changed  eth0    true
+
+  1 host: 1 changed
 ```
 
 Broadcast delete to all hosts:
@@ -21,12 +23,14 @@ $ osapi client node network interface delete \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CHANGED
-  web-01    eth1    true
-  web-02    eth1    true
+  HOSTNAME  STATUS   NAME    CHANGED
+  web-01    changed  eth1    true
+  web-02    changed  eth1    true
+
+  2 hosts: 2 changed
 ```
 
-When some hosts are skipped, STATUS and ERROR columns are added:
+When some hosts are skipped:
 
 ```bash
 $ osapi client node network interface delete \
@@ -34,9 +38,14 @@ $ osapi client node network interface delete \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   NAME    CHANGED  ERROR
-  web-01    ok       eth1    true
-  mac-01    skipped                   unsupported platform
+  HOSTNAME  STATUS   NAME    CHANGED
+  web-01    changed  eth1    true
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/network/interface/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/interface/list.md
@@ -7,9 +7,11 @@ $ osapi client node network interface list --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    IPV4                DHCP    PRIMARY
-  web-01    eth0    192.168.1.100/24    static  yes
-  web-01    lo      127.0.0.1/8
+  HOSTNAME  STATUS  NAME    IPV4                DHCP    PRIMARY
+  web-01    ok      eth0    192.168.1.100/24    static  yes
+  web-01    ok      lo      127.0.0.1/8
+
+  1 host: 1 ok
 ```
 
 Target all hosts to list interfaces across the fleet:
@@ -19,9 +21,11 @@ $ osapi client node network interface list --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    IPV4                DHCP    PRIMARY
-  web-01    eth0    192.168.1.100/24    static  yes
-  web-02    eth0    192.168.1.200/24    static  yes
+  HOSTNAME  STATUS  NAME    IPV4                DHCP    PRIMARY
+  web-01    ok      eth0    192.168.1.100/24    static  yes
+  web-02    ok      eth0    192.168.1.200/24    static  yes
+
+  2 hosts: 2 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/network/interface/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/interface/update.md
@@ -13,8 +13,10 @@ $ osapi client node network interface update \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CHANGED
-  web-01    eth0    true
+  HOSTNAME  STATUS   NAME    CHANGED
+  web-01    changed  eth0    true
+
+  1 host: 1 changed
 ```
 
 When the configuration is unchanged, `changed` is false:
@@ -28,8 +30,10 @@ $ osapi client node network interface update \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CHANGED
-  web-01    eth0    false
+  HOSTNAME  STATUS  NAME    CHANGED
+  web-01    ok      eth0    false
+
+  1 host: 1 ok
 ```
 
 Broadcast an update to all hosts:
@@ -40,9 +44,11 @@ $ osapi client node network interface update \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CHANGED
-  web-01    eth0    true
-  web-02    eth0    true
+  HOSTNAME  STATUS   NAME    CHANGED
+  web-01    changed  eth0    true
+  web-02    changed  eth0    true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/network/ping/ping.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/ping/ping.md
@@ -7,9 +7,10 @@ $ osapi client node network ping --address 8.8.8.8
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  Ping Response:
-  HOSTNAME  AVG RTT       MAX RTT       MIN RTT       PACKET LOSS  PACKETS RECEIVED  PACKETS SENT
-  server1   19.707031ms   25.066977ms   13.007048ms   0.000000     3                 3
+  HOSTNAME  STATUS  AVG          MIN          MAX          LOSS
+  server1   ok      19.707031ms  13.007048ms  25.066977ms  0.000000
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -19,23 +20,28 @@ $ osapi client node network ping --address 8.8.8.8 --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  Ping Response:
-  HOSTNAME  AVG RTT      MAX RTT      MIN RTT      PACKET LOSS  PACKETS RECEIVED  PACKETS SENT
-  server1   19.707031ms  25.066977ms  13.007048ms  0.000000     3                 3
-  server2   22.345678ms  28.123456ms  18.234567ms  0.000000     3                 3
+  HOSTNAME  STATUS  AVG          MIN          MAX          LOSS
+  server1   ok      19.707031ms  13.007048ms  25.066977ms  0.000000
+  server2   ok      22.345678ms  18.234567ms  28.123456ms  0.000000
+
+  2 hosts: 2 ok
 ```
 
-When some hosts fail or are skipped, STATUS and ERROR columns are shown:
+When some hosts fail or are skipped:
 
 ```bash
 $ osapi client node network ping --address 8.8.8.8 --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  Ping Response:
-  HOSTNAME  STATUS   AVG RTT      PACKET LOSS  PACKETS RECEIVED  ERROR
-  server1   ok       19.707031ms  0.000000     3
-  server2   skipped                                               unsupported platform
+  HOSTNAME  STATUS  AVG          MIN          MAX          LOSS
+  server1   ok      19.707031ms  13.007048ms  25.066977ms  0.000000
+  server2   skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 Target by label to ping from a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/network/route/create.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/route/create.md
@@ -11,8 +11,10 @@ $ osapi client node network route create \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  INTERFACE  CHANGED
-  web-01    eth0       true
+  HOSTNAME  STATUS   INTERFACE  CHANGED
+  web-01    changed  eth0       true
+
+  1 host: 1 changed
 ```
 
 Create multiple routes at once:
@@ -25,8 +27,10 @@ $ osapi client node network route create \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  INTERFACE  CHANGED
-  web-01    eth0       true
+  HOSTNAME  STATUS   INTERFACE  CHANGED
+  web-01    changed  eth0       true
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts at once:
@@ -38,17 +42,24 @@ $ osapi client node network route create \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  INTERFACE  CHANGED
-  web-01    eth0       true
-  web-02    eth0       true
+  HOSTNAME  STATUS   INTERFACE  CHANGED
+  web-01    changed  eth0       true
+  web-02    changed  eth0       true
+
+  2 hosts: 2 changed
 ```
 
-When some hosts are skipped, STATUS and ERROR columns are added:
+When some hosts are skipped:
 
 ```bash
-  HOSTNAME  STATUS   INTERFACE  CHANGED  ERROR
-  web-01    ok       eth0       true
-  mac-01    skipped                      unsupported platform
+  HOSTNAME  STATUS   INTERFACE  CHANGED
+  web-01    changed  eth0       true
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## Route Format

--- a/docs/docs/sidebar/usage/cli/client/node/network/route/delete.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/route/delete.md
@@ -9,8 +9,10 @@ $ osapi client node network route delete \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  INTERFACE  CHANGED
-  web-01    eth0       true
+  HOSTNAME  STATUS   INTERFACE  CHANGED
+  web-01    changed  eth0       true
+
+  1 host: 1 changed
 ```
 
 Broadcast delete to all hosts:
@@ -21,12 +23,14 @@ $ osapi client node network route delete \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  INTERFACE  CHANGED
-  web-01    eth0       true
-  web-02    eth0       true
+  HOSTNAME  STATUS   INTERFACE  CHANGED
+  web-01    changed  eth0       true
+  web-02    changed  eth0       true
+
+  2 hosts: 2 changed
 ```
 
-When some hosts are skipped, STATUS and ERROR columns are added:
+When some hosts are skipped:
 
 ```bash
 $ osapi client node network route delete \
@@ -34,9 +38,14 @@ $ osapi client node network route delete \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   INTERFACE  CHANGED  ERROR
-  web-01    ok       eth0       true
-  mac-01    skipped                      unsupported platform
+  HOSTNAME  STATUS   INTERFACE  CHANGED
+  web-01    changed  eth0       true
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/network/route/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/route/get.md
@@ -8,9 +8,11 @@ $ osapi client node network route get \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  DESTINATION   GATEWAY      INTERFACE  METRIC
-  web-01    10.0.0.0/8    192.168.1.1  eth0       0
-  web-01    172.16.0.0/12 192.168.1.1  eth0       100
+  HOSTNAME  STATUS  DESTINATION   GATEWAY      INTERFACE  METRIC
+  web-01    ok      10.0.0.0/8    192.168.1.1  eth0       0
+  web-01    ok      172.16.0.0/12 192.168.1.1  eth0       100
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -21,12 +23,14 @@ $ osapi client node network route get \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  DESTINATION   GATEWAY      INTERFACE  METRIC
-  web-01    10.0.0.0/8    192.168.1.1  eth0       0
-  web-02    10.0.0.0/8    192.168.1.1  eth0       0
+  HOSTNAME  STATUS  DESTINATION   GATEWAY      INTERFACE  METRIC
+  web-01    ok      10.0.0.0/8    192.168.1.1  eth0       0
+  web-02    ok      10.0.0.0/8    192.168.1.1  eth0       0
+
+  2 hosts: 2 ok
 ```
 
-When some hosts fail or are skipped, STATUS and ERROR columns are shown:
+When some hosts fail or are skipped:
 
 ```bash
 $ osapi client node network route get \
@@ -34,9 +38,14 @@ $ osapi client node network route get \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   DESTINATION   GATEWAY  INTERFACE  METRIC  ERROR
-  web-01    ok       10.0.0.0/8    ...
-  mac-01    skipped                                             unsupported platform
+  HOSTNAME  STATUS  DESTINATION   GATEWAY      INTERFACE  METRIC
+  web-01    ok      10.0.0.0/8    192.168.1.1  eth0       0
+  mac-01    skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/network/route/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/route/list.md
@@ -7,10 +7,12 @@ $ osapi client node network route list --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  DESTINATION     GATEWAY        INTERFACE  METRIC
-  web-01    0.0.0.0/0       192.168.1.1    eth0       100
-  web-01    10.0.0.0/8      192.168.1.1    eth0       0
-  web-01    192.168.1.0/24  0.0.0.0        eth0       0
+  HOSTNAME  STATUS  DESTINATION     GATEWAY        INTERFACE  METRIC
+  web-01    ok      0.0.0.0/0       192.168.1.1    eth0       100
+  web-01    ok      10.0.0.0/8      192.168.1.1    eth0       0
+  web-01    ok      192.168.1.0/24  0.0.0.0        eth0       0
+
+  1 host: 1 ok
 ```
 
 Target all hosts to list routes across the fleet:
@@ -20,11 +22,13 @@ $ osapi client node network route list --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  DESTINATION     GATEWAY        INTERFACE  METRIC
-  web-01    0.0.0.0/0       192.168.1.1    eth0       100
-  web-01    192.168.1.0/24  0.0.0.0        eth0       0
-  web-02    0.0.0.0/0       10.0.0.1       eth0       100
-  web-02    10.0.0.0/24     0.0.0.0        eth0       0
+  HOSTNAME  STATUS  DESTINATION     GATEWAY        INTERFACE  METRIC
+  web-01    ok      0.0.0.0/0       192.168.1.1    eth0       100
+  web-01    ok      192.168.1.0/24  0.0.0.0        eth0       0
+  web-02    ok      0.0.0.0/0       10.0.0.1       eth0       100
+  web-02    ok      10.0.0.0/24     0.0.0.0        eth0       0
+
+  2 hosts: 2 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/network/route/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/network/route/update.md
@@ -12,8 +12,10 @@ $ osapi client node network route update \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  INTERFACE  CHANGED
-  web-01    eth0       true
+  HOSTNAME  STATUS   INTERFACE  CHANGED
+  web-01    changed  eth0       true
+
+  1 host: 1 changed
 ```
 
 When the configuration is unchanged, `changed` is false:
@@ -25,8 +27,10 @@ $ osapi client node network route update \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  INTERFACE  CHANGED
-  web-01    eth0       false
+  HOSTNAME  STATUS  INTERFACE  CHANGED
+  web-01    ok      eth0       false
+
+  1 host: 1 ok
 ```
 
 Broadcast an update to all hosts:
@@ -38,9 +42,11 @@ $ osapi client node network route update \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  INTERFACE  CHANGED
-  web-01    eth0       true
-  web-02    eth0       true
+  HOSTNAME  STATUS   INTERFACE  CHANGED
+  web-01    changed  eth0       true
+  web-02    changed  eth0       true
+
+  2 hosts: 2 changed
 ```
 
 ## Route Format

--- a/docs/docs/sidebar/usage/cli/client/node/ntp/create.md
+++ b/docs/docs/sidebar/usage/cli/client/node/ntp/create.md
@@ -11,8 +11,10 @@ $ osapi client node ntp create --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
-  web-01    ok      true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts at once:
@@ -23,9 +25,11 @@ $ osapi client node ntp create --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
-  web-01    ok      true
-  web-02    ok      true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+  web-02    changed  true
+
+  2 hosts: 2 changed
 ```
 
 When some hosts are skipped (e.g., macOS agents):
@@ -36,9 +40,14 @@ $ osapi client node ntp create --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR
-  web-01    ok       true
-  mac-01    skipped           unsupported platform
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/ntp/delete.md
+++ b/docs/docs/sidebar/usage/cli/client/node/ntp/delete.md
@@ -9,8 +9,10 @@ $ osapi client node ntp delete --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
-  web-01    ok      true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
 If the configuration does not exist, `changed: false` is returned:
@@ -20,8 +22,10 @@ $ osapi client node ntp delete --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
+  HOSTNAME  STATUS  CHANGED
   web-01    ok      false
+
+  1 host: 1 ok
 ```
 
 Broadcast to all hosts:
@@ -31,9 +35,11 @@ $ osapi client node ntp delete --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR
-  web-01    ok       true
-  web-02    ok       true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+  web-02    changed  true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/ntp/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/ntp/get.md
@@ -7,8 +7,10 @@ $ osapi client node ntp get --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  SYNCHRONIZED  STRATUM  OFFSET    SOURCE     SERVERS
-  web-01    yes           2        +0.000123  192.0.2.1  0.pool.ntp.org, 1.pool.ntp.org
+  HOSTNAME  STATUS  SYNCHRONIZED  SOURCE     SERVERS
+  web-01    ok      yes           192.0.2.1  0.pool.ntp.org, 1.pool.ntp.org
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -18,22 +20,28 @@ $ osapi client node ntp get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  SYNCHRONIZED  STRATUM  OFFSET     SOURCE     SERVERS
-  web-01    yes           2        +0.000123  192.0.2.1  0.pool.ntp.org, 1.pool.ntp.org
-  web-02    yes           2        +0.000045  192.0.2.1  0.pool.ntp.org, 1.pool.ntp.org
+  HOSTNAME  STATUS  SYNCHRONIZED  SOURCE     SERVERS
+  web-01    ok      yes           192.0.2.1  0.pool.ntp.org, 1.pool.ntp.org
+  web-02    ok      yes           192.0.2.1  0.pool.ntp.org, 1.pool.ntp.org
+
+  2 hosts: 2 ok
 ```
 
-When some hosts are skipped, STATUS and ERROR columns appear alongside data
-columns:
+When some hosts are skipped:
 
 ```bash
 $ osapi client node ntp get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   ERROR                 SYNCHRONIZED  STRATUM  OFFSET     SOURCE     SERVERS
-  web-01    ok                              yes           2        +0.000123  192.0.2.1  0.pool.ntp.org
-  mac-01    skipped  unsupported platform
+  HOSTNAME  STATUS  SYNCHRONIZED  SOURCE     SERVERS
+  web-01    ok      yes           192.0.2.1  0.pool.ntp.org
+  mac-01    skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/ntp/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/ntp/update.md
@@ -10,8 +10,10 @@ $ osapi client node ntp update --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
-  web-01    ok      true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
 If the server list is already identical, `changed: false` is returned and the
@@ -23,8 +25,10 @@ $ osapi client node ntp update --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
+  HOSTNAME  STATUS  CHANGED
   web-01    ok      false
+
+  1 host: 1 ok
 ```
 
 Broadcast to all hosts at once:
@@ -35,9 +39,11 @@ $ osapi client node ntp update --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR
-  web-01    ok       true
-  web-02    ok       true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+  web-02    changed  true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/os/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/os/get.md
@@ -7,8 +7,10 @@ $ osapi client node os get
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  DISTRIBUTION  VERSION
-  web-01    Ubuntu        24.04
+  HOSTNAME  STATUS  DISTRIBUTION  VERSION
+  web-01    ok      Ubuntu        24.04
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -18,9 +20,11 @@ $ osapi client node os get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  DISTRIBUTION  VERSION
-  server1   Ubuntu        24.04
-  server2   Debian        12
+  HOSTNAME  STATUS  DISTRIBUTION  VERSION
+  server1   ok      Ubuntu        24.04
+  server2   ok      Debian        12
+
+  2 hosts: 2 ok
 ```
 
 When some hosts fail or are skipped:
@@ -30,9 +34,14 @@ $ osapi client node os get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   DISTRIBUTION  VERSION  ERROR
-  server1   ok       Ubuntu        24.04
-  server2   skipped                          unsupported platform
+  HOSTNAME  STATUS  DISTRIBUTION  VERSION
+  server1   ok      Ubuntu        24.04
+  server2   skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 Target by label to query a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/package/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/package/get.md
@@ -7,8 +7,10 @@ $ osapi client node package get --target web-01 --name nginx
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    VERSION    STATUS      SIZE
-  web-01    nginx   1.24.0-2   installed   1.2 MB
+  HOSTNAME  STATUS  NAME    VERSION    PKG STATUS
+  web-01    ok      nginx   1.24.0-2   installed
+
+  1 host: 1 ok
 ```
 
 Broadcast to see the package across all hosts:
@@ -18,22 +20,28 @@ $ osapi client node package get --target _all --name nginx
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    VERSION    STATUS      SIZE
-  web-01    nginx   1.24.0-2   installed   1.2 MB
-  web-02    nginx   1.24.0-2   installed   1.2 MB
+  HOSTNAME  STATUS  NAME    VERSION    PKG STATUS
+  web-01    ok      nginx   1.24.0-2   installed
+  web-02    ok      nginx   1.24.0-2   installed
+
+  2 hosts: 2 ok
 ```
 
-When some hosts are skipped, STATUS and ERROR columns appear alongside data
-columns:
+When some hosts are skipped:
 
 ```bash
 $ osapi client node package get --target _all --name nginx
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   ERROR                 NAME    VERSION    STATUS      SIZE
-  web-01    ok                              nginx   1.24.0-2   installed   1.2 MB
-  mac-01    skipped  unsupported platform
+  HOSTNAME  STATUS  NAME    VERSION    PKG STATUS
+  web-01    ok      nginx   1.24.0-2   installed
+  mac-01    skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/package/install.md
+++ b/docs/docs/sidebar/usage/cli/client/node/package/install.md
@@ -7,8 +7,10 @@ $ osapi client node package install --target web-01 --name nginx
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  NAME
-  web-01    ok      true            nginx
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     nginx
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts at once:
@@ -18,10 +20,15 @@ $ osapi client node package install --target _all --name htop
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR                 NAME
-  web-01    ok       true                            htop
-  web-02    ok       true                            htop
-  mac-01    skipped  false    unsupported platform
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     htop
+  web-02    changed  true     htop
+  mac-01    skip
+
+  3 hosts: 2 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/package/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/package/list.md
@@ -7,10 +7,12 @@ $ osapi client node package list --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME      VERSION      STATUS      SIZE
-  web-01    bash      5.2.21-2     installed   7.4 MB
-  web-01    nginx     1.24.0-2     installed   1.2 MB
-  web-01    curl      8.5.0-2      installed   512.0 KB
+  HOSTNAME  STATUS  NAME      VERSION      PKG STATUS
+  web-01    ok      bash      5.2.21-2     installed
+  web-01    ok      nginx     1.24.0-2     installed
+  web-01    ok      curl      8.5.0-2      installed
+
+  1 host: 1 ok
 ```
 
 Target all hosts to list packages across the fleet:
@@ -20,24 +22,30 @@ $ osapi client node package list --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME      VERSION      STATUS      SIZE
-  web-01    bash      5.2.21-2     installed   7.4 MB
-  web-01    nginx     1.24.0-2     installed   1.2 MB
-  web-02    bash      5.2.21-2     installed   7.4 MB
+  HOSTNAME  STATUS  NAME      VERSION      PKG STATUS
+  web-01    ok      bash      5.2.21-2     installed
+  web-01    ok      nginx     1.24.0-2     installed
+  web-02    ok      bash      5.2.21-2     installed
+
+  2 hosts: 2 ok
 ```
 
-When some hosts are skipped, STATUS and ERROR columns appear alongside data
-columns:
+When some hosts are skipped:
 
 ```bash
 $ osapi client node package list --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   ERROR                 NAME      VERSION      STATUS      SIZE
-  web-01    ok                              bash      5.2.21-2     installed   7.4 MB
-  web-01    ok                              nginx     1.24.0-2     installed   1.2 MB
-  mac-01    skipped  unsupported platform
+  HOSTNAME  STATUS  NAME      VERSION      PKG STATUS
+  web-01    ok      bash      5.2.21-2     installed
+  web-01    ok      nginx     1.24.0-2     installed
+  mac-01    skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 Target by label to list packages on a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/package/remove.md
+++ b/docs/docs/sidebar/usage/cli/client/node/package/remove.md
@@ -7,8 +7,10 @@ $ osapi client node package remove --target web-01 --name nginx
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  NAME
-  web-01    ok      true            nginx
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     nginx
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts at once:
@@ -18,10 +20,15 @@ $ osapi client node package remove --target _all --name nginx
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR                 NAME
-  web-01    ok       true                            nginx
-  web-02    ok       true                            nginx
-  mac-01    skipped  false    unsupported platform
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     nginx
+  web-02    changed  true     nginx
+  mac-01    skip
+
+  3 hosts: 2 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/package/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/package/update.md
@@ -8,8 +8,10 @@ $ osapi client node package update --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
-  web-01    ok      true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
 Broadcast to refresh sources across all hosts:
@@ -19,10 +21,15 @@ $ osapi client node package update --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR
-  web-01    ok       true
-  web-02    ok       true
-  mac-01    skipped  false    unsupported platform
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+  web-02    changed  true
+  mac-01    skip
+
+  3 hosts: 2 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/package/updates.md
+++ b/docs/docs/sidebar/usage/cli/client/node/package/updates.md
@@ -7,9 +7,11 @@ $ osapi client node package updates --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CURRENT      NEW
-  web-01    nginx   1.24.0-2     1.26.0-1
-  web-01    curl    8.5.0-2      8.7.1-1
+  HOSTNAME  STATUS  NAME    CURRENT      NEW
+  web-01    ok      nginx   1.24.0-2     1.26.0-1
+  web-01    ok      curl    8.5.0-2      8.7.1-1
+
+  1 host: 1 ok
 ```
 
 Broadcast to check for updates across all hosts:
@@ -19,23 +21,29 @@ $ osapi client node package updates --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME    CURRENT      NEW
-  web-01    nginx   1.24.0-2     1.26.0-1
-  web-01    curl    8.5.0-2      8.7.1-1
-  web-02    nginx   1.24.0-2     1.26.0-1
+  HOSTNAME  STATUS  NAME    CURRENT      NEW
+  web-01    ok      nginx   1.24.0-2     1.26.0-1
+  web-01    ok      curl    8.5.0-2      8.7.1-1
+  web-02    ok      nginx   1.24.0-2     1.26.0-1
+
+  2 hosts: 2 ok
 ```
 
-When some hosts are skipped, STATUS and ERROR columns appear alongside data
-columns:
+When some hosts are skipped:
 
 ```bash
 $ osapi client node package updates --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   ERROR                 NAME    CURRENT      NEW
-  web-01    ok                              nginx   1.24.0-2     1.26.0-1
-  mac-01    skipped  unsupported platform
+  HOSTNAME  STATUS  NAME    CURRENT      NEW
+  web-01    ok      nginx   1.24.0-2     1.26.0-1
+  mac-01    skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/power/reboot.md
+++ b/docs/docs/sidebar/usage/cli/client/node/power/reboot.md
@@ -8,8 +8,10 @@ $ osapi client node power reboot --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  ACTION  DELAY
-  web-01    ok      true            reboot  0
+  HOSTNAME  STATUS   CHANGED  ACTION  DELAY
+  web-01    changed  true     reboot  0
+
+  1 host: 1 changed
 ```
 
 Reboot with a 60-second delay and a broadcast message:
@@ -20,8 +22,10 @@ $ osapi client node power reboot --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  ACTION  DELAY
-  web-01    ok      true            reboot  60
+  HOSTNAME  STATUS   CHANGED  ACTION  DELAY
+  web-01    changed  true     reboot  60
+
+  1 host: 1 changed
 ```
 
 Broadcast reboot to all hosts at once:
@@ -31,9 +35,14 @@ $ osapi client node power reboot --target _all --delay 30
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR                ACTION  DELAY
-  web-01    ok       true                           reboot  30
-  mac-01    skipped           unsupported platform
+  HOSTNAME  STATUS   CHANGED  ACTION  DELAY
+  web-01    changed  true     reboot  30
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/power/shutdown.md
+++ b/docs/docs/sidebar/usage/cli/client/node/power/shutdown.md
@@ -8,8 +8,10 @@ $ osapi client node power shutdown --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  ACTION    DELAY
-  web-01    ok      true            shutdown  0
+  HOSTNAME  STATUS   CHANGED  ACTION    DELAY
+  web-01    changed  true     shutdown  0
+
+  1 host: 1 changed
 ```
 
 Shutdown with a 60-second delay and a broadcast message:
@@ -20,8 +22,10 @@ $ osapi client node power shutdown --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  ACTION    DELAY
-  web-01    ok      true            shutdown  60
+  HOSTNAME  STATUS   CHANGED  ACTION    DELAY
+  web-01    changed  true     shutdown  60
+
+  1 host: 1 changed
 ```
 
 Broadcast shutdown to all hosts at once:
@@ -31,9 +35,14 @@ $ osapi client node power shutdown --target _all --delay 30
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   CHANGED  ERROR                ACTION    DELAY
-  web-01    ok       true                           shutdown  30
-  mac-01    skipped           unsupported platform
+  HOSTNAME  STATUS   CHANGED  ACTION    DELAY
+  web-01    changed  true     shutdown  30
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/process/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/process/get.md
@@ -7,8 +7,10 @@ $ osapi client node process get --target web-01 --pid 1234
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  PID   NAME   USER  STATE     CPU%  MEM%  COMMAND
-  web-01    1234  nginx  www   sleeping  2.3%  1.5%  nginx: worker process
+  HOSTNAME  STATUS  PID   NAME   USER  STATE     CPU%  COMMAND
+  web-01    ok      1234  nginx  www   sleeping  2.3%  nginx: worker process
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -18,9 +20,11 @@ $ osapi client node process get --target _all --pid 1
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  PID  NAME     USER  STATE     CPU%  MEM%  COMMAND
-  web-01    1    systemd  root  sleeping  0.0%  0.1%  /sbin/init
-  web-02    1    systemd  root  sleeping  0.0%  0.1%  /sbin/init
+  HOSTNAME  STATUS  PID  NAME     USER  STATE     CPU%  COMMAND
+  web-01    ok      1    systemd  root  sleeping  0.0%  /sbin/init
+  web-02    ok      1    systemd  root  sleeping  0.0%  /sbin/init
+
+  2 hosts: 2 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/process/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/process/list.md
@@ -7,10 +7,12 @@ $ osapi client node process list --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  PID   NAME      USER  STATE     CPU%  MEM%  COMMAND
-  web-01    1     systemd   root  sleeping  0.0%  0.1%  /sbin/init
-  web-01    245   sshd      root  sleeping  0.0%  0.2%  sshd: /usr/sbin/sshd -D
-  web-01    1234  nginx     www   sleeping  2.3%  1.5%  nginx: worker process
+  HOSTNAME  STATUS  PID   NAME      USER  STATE     CPU%  COMMAND
+  web-01    ok      1     systemd   root  sleeping  0.0%  /sbin/init
+  web-01    ok      245   sshd      root  sleeping  0.0%  sshd: /usr/sbin/sshd -D
+  web-01    ok      1234  nginx     www   sleeping  2.3%  nginx: worker process
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -20,11 +22,13 @@ $ osapi client node process list --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  PID   NAME      USER  STATE     CPU%  MEM%  COMMAND
-  web-01    1     systemd   root  sleeping  0.0%  0.1%  /sbin/init
-  web-01    1234  nginx     www   sleeping  2.3%  1.5%  nginx: worker process
-  web-02    1     systemd   root  sleeping  0.0%  0.1%  /sbin/init
-  web-02    5678  postgres  pg    sleeping  1.1%  3.2%  postgres: writer process
+  HOSTNAME  STATUS  PID   NAME      USER  STATE     CPU%  COMMAND
+  web-01    ok      1     systemd   root  sleeping  0.0%  /sbin/init
+  web-01    ok      1234  nginx     www   sleeping  2.3%  nginx: worker process
+  web-02    ok      1     systemd   root  sleeping  0.0%  /sbin/init
+  web-02    ok      5678  postgres  pg    sleeping  1.1%  postgres: writer process
+
+  2 hosts: 2 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/process/signal.md
+++ b/docs/docs/sidebar/usage/cli/client/node/process/signal.md
@@ -8,8 +8,10 @@ $ osapi client node process signal --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  PID   SIGNAL  CHANGED
-  web-01    1234  TERM    true
+  HOSTNAME  STATUS   PID   SIGNAL  CHANGED
+  web-01    changed  1234  TERM    true
+
+  1 host: 1 changed
 ```
 
 Broadcast a signal to a process on all hosts:
@@ -20,10 +22,15 @@ $ osapi client node process signal --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   PID   SIGNAL  CHANGED  ERROR
-  web-01    ok       1234  HUP     true
-  web-02    ok       1234  HUP     true
-  mac-01    skipped                         unsupported platform
+  HOSTNAME  STATUS   PID   SIGNAL  CHANGED
+  web-01    changed  1234  HUP     true
+  web-02    changed  1234  HUP     true
+  mac-01    skip
+
+  3 hosts: 2 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/schedule/cron.md
+++ b/docs/docs/sidebar/usage/cli/client/node/schedule/cron.md
@@ -13,9 +13,11 @@ List all osapi-managed cron entries:
 ```bash
 $ osapi client node schedule cron list --target web-01
 
-  HOSTNAME  NAME           SCHEDULE     USER  OBJECT
-  web-01    backup-daily   0 2 * * *    root  backup-script
-  web-01    log-rotate     0 0 * * 0    root  logrotate-conf
+  HOSTNAME  STATUS  NAME           SCHEDULE     OBJECT          USER
+  web-01    ok      backup-daily   0 2 * * *    backup-script   root
+  web-01    ok      log-rotate     0 0 * * 0    logrotate-conf  root
+
+  1 host: 1 ok
 ```
 
 ## Get
@@ -25,10 +27,10 @@ Get a specific cron entry by name:
 ```bash
 $ osapi client node schedule cron get --target web-01 --name backup-daily
 
-  Name:     backup-daily
-  Schedule: 0 2 * * *
-  User:     root
-  Object:   backup-script
+  HOSTNAME  STATUS  NAME           SCHEDULE     OBJECT          USER
+  web-01    ok      backup-daily   0 2 * * *    backup-script   root
+
+  1 host: 1 ok
 ```
 
 ## Create
@@ -50,9 +52,10 @@ $ osapi client node schedule cron create --target web-01 \
     --object backup-script \
     --user root
 
-  Name:    backup-daily
-  Status:  ok
-  Changed: true
+  HOSTNAME  STATUS   NAME          CHANGED
+  web-01    changed  backup-daily  true
+
+  1 host: 1 changed
 ```
 
 The `--user` flag defaults to `root` if omitted.
@@ -69,9 +72,10 @@ $ osapi client node schedule cron update --target web-01 \
     --name backup-daily \
     --schedule "0 3 * * *"
 
-  Name:    backup-daily
-  Status:  ok
-  Changed: true
+  HOSTNAME  STATUS   NAME          CHANGED
+  web-01    changed  backup-daily  true
+
+  1 host: 1 changed
 ```
 
 Only the fields you specify are updated. If nothing changed, `Changed: false`.
@@ -83,9 +87,10 @@ Delete a cron entry:
 ```bash
 $ osapi client node schedule cron delete --target web-01 --name backup-daily
 
-  Name:    backup-daily
-  Status:  ok
-  Changed: true
+  HOSTNAME  STATUS   NAME          CHANGED
+  web-01    changed  backup-daily  true
+
+  1 host: 1 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/create.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/create.md
@@ -11,8 +11,10 @@ $ osapi client node service create --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    myapp.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  myapp.service    true
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts at once:
@@ -23,13 +25,14 @@ $ osapi client node service create --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    myapp.service    true
-  web-02    myapp.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  myapp.service    true
+  web-02    changed  myapp.service    true
+
+  2 hosts: 2 changed
 ```
 
-When some hosts are skipped (e.g., macOS agents), STATUS and ERROR columns are
-added:
+When some hosts are skipped (e.g., macOS agents):
 
 ```bash
 $ osapi client node service create --target _all \
@@ -37,9 +40,14 @@ $ osapi client node service create --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   NAME             CHANGED  ERROR
-  web-01    ok       myapp.service    true
-  mac-01    skipped                            unsupported platform
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  myapp.service    true
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/delete.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/delete.md
@@ -10,8 +10,10 @@ $ osapi client node service delete --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    myapp.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  myapp.service    true
+
+  1 host: 1 changed
 ```
 
 If the unit file does not exist, `changed: false` is returned:
@@ -22,8 +24,10 @@ $ osapi client node service delete --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    myapp.service    false
+  HOSTNAME  STATUS  NAME             CHANGED
+  web-01    ok      myapp.service    false
+
+  1 host: 1 ok
 ```
 
 Broadcast to all hosts:
@@ -34,9 +38,11 @@ $ osapi client node service delete --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    myapp.service    true
-  web-02    myapp.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  myapp.service    true
+  web-02    changed  myapp.service    true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/disable.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/disable.md
@@ -9,8 +9,10 @@ $ osapi client node service disable --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+
+  1 host: 1 changed
 ```
 
 If the service is already disabled, `changed: false` is returned:
@@ -21,8 +23,10 @@ $ osapi client node service disable --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    false
+  HOSTNAME  STATUS  NAME             CHANGED
+  web-01    ok      nginx.service    false
+
+  1 host: 1 ok
 ```
 
 Broadcast disable to all hosts:
@@ -33,9 +37,11 @@ $ osapi client node service disable --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
-  web-02    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+  web-02    changed  nginx.service    true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/enable.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/enable.md
@@ -9,8 +9,10 @@ $ osapi client node service enable --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+
+  1 host: 1 changed
 ```
 
 If the service is already enabled, `changed: false` is returned:
@@ -21,8 +23,10 @@ $ osapi client node service enable --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    false
+  HOSTNAME  STATUS  NAME             CHANGED
+  web-01    ok      nginx.service    false
+
+  1 host: 1 ok
 ```
 
 Broadcast enable to all hosts:
@@ -33,9 +37,11 @@ $ osapi client node service enable --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
-  web-02    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+  web-02    changed  nginx.service    true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/get.md
@@ -7,8 +7,10 @@ $ osapi client node service get --target web-01 --name nginx.service
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             STATUS  ENABLED  DESCRIPTION                       PID
-  web-01    nginx.service    active  true     A high performance web server     1234
+  HOSTNAME  STATUS  NAME             ACTIVE  ENABLED  DESCRIPTION
+  web-01    ok      nginx.service    active  true     A high performance web server
+
+  1 host: 1 ok
 ```
 
 Target all hosts to inspect the same service across the fleet:
@@ -18,9 +20,11 @@ $ osapi client node service get --target _all --name nginx.service
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             STATUS  ENABLED  DESCRIPTION                       PID
-  web-01    nginx.service    active  true     A high performance web server     1234
-  web-02    nginx.service    active  true     A high performance web server     5678
+  HOSTNAME  STATUS  NAME             ACTIVE  ENABLED  DESCRIPTION
+  web-01    ok      nginx.service    active  true     A high performance web server
+  web-02    ok      nginx.service    active  true     A high performance web server
+
+  2 hosts: 2 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/list.md
@@ -7,10 +7,12 @@ $ osapi client node service list --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             STATUS    ENABLED  DESCRIPTION
-  web-01    nginx.service    active    true     A high performance web server
-  web-01    ssh.service      active    true     OpenBSD Secure Shell server
-  web-01    cron.service     active    true     Regular background program processing
+  HOSTNAME  STATUS  NAME             ACTIVE  ENABLED
+  web-01    ok      nginx.service    active  true
+  web-01    ok      ssh.service      active  true
+  web-01    ok      cron.service     active  true
+
+  1 host: 1 ok
 ```
 
 Target all hosts to list services across the fleet:
@@ -20,11 +22,13 @@ $ osapi client node service list --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             STATUS    ENABLED  DESCRIPTION
-  web-01    nginx.service    active    true     A high performance web server
-  web-01    ssh.service      active    true     OpenBSD Secure Shell server
-  web-02    nginx.service    active    true     A high performance web server
-  web-02    ssh.service      active    true     OpenBSD Secure Shell server
+  HOSTNAME  STATUS  NAME             ACTIVE  ENABLED
+  web-01    ok      nginx.service    active  true
+  web-01    ok      ssh.service      active  true
+  web-02    ok      nginx.service    active  true
+  web-02    ok      ssh.service      active  true
+
+  2 hosts: 2 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/restart.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/restart.md
@@ -9,8 +9,10 @@ $ osapi client node service restart --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+
+  1 host: 1 changed
 ```
 
 Broadcast restart to all hosts:
@@ -21,13 +23,14 @@ $ osapi client node service restart --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
-  web-02    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+  web-02    changed  nginx.service    true
+
+  2 hosts: 2 changed
 ```
 
-When some hosts are skipped (e.g., macOS agents), STATUS and ERROR columns are
-added:
+When some hosts are skipped (e.g., macOS agents):
 
 ```bash
 $ osapi client node service restart --target _all \
@@ -35,9 +38,14 @@ $ osapi client node service restart --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   NAME             CHANGED  ERROR
-  web-01    ok       nginx.service    true
-  mac-01    skipped                            unsupported platform
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/start.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/start.md
@@ -9,8 +9,10 @@ $ osapi client node service start --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+
+  1 host: 1 changed
 ```
 
 If the service is already running, `changed: false` is returned:
@@ -21,8 +23,10 @@ $ osapi client node service start --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    false
+  HOSTNAME  STATUS  NAME             CHANGED
+  web-01    ok      nginx.service    false
+
+  1 host: 1 ok
 ```
 
 Broadcast start to all hosts:
@@ -33,9 +37,11 @@ $ osapi client node service start --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
-  web-02    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+  web-02    changed  nginx.service    true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/stop.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/stop.md
@@ -9,8 +9,10 @@ $ osapi client node service stop --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+
+  1 host: 1 changed
 ```
 
 If the service is already stopped, `changed: false` is returned:
@@ -21,8 +23,10 @@ $ osapi client node service stop --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    false
+  HOSTNAME  STATUS  NAME             CHANGED
+  web-01    ok      nginx.service    false
+
+  1 host: 1 ok
 ```
 
 Broadcast stop to all hosts:
@@ -33,9 +37,11 @@ $ osapi client node service stop --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    nginx.service    true
-  web-02    nginx.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  nginx.service    true
+  web-02    changed  nginx.service    true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/service/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/service/update.md
@@ -10,8 +10,10 @@ $ osapi client node service update --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    myapp.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  myapp.service    true
+
+  1 host: 1 changed
 ```
 
 If the content has not changed (same SHA), `changed: false` is returned:
@@ -22,8 +24,10 @@ $ osapi client node service update --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    myapp.service    false
+  HOSTNAME  STATUS  NAME             CHANGED
+  web-01    ok      myapp.service    false
+
+  1 host: 1 ok
 ```
 
 Broadcast to all hosts at once:
@@ -34,9 +38,11 @@ $ osapi client node service update --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  NAME             CHANGED
-  web-01    myapp.service    true
-  web-02    myapp.service    true
+  HOSTNAME  STATUS   NAME             CHANGED
+  web-01    changed  myapp.service    true
+  web-02    changed  myapp.service    true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/status/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/status/get.md
@@ -12,9 +12,9 @@ $ osapi client node status get
   Memory: 19 GB used / 31 GB total / 10 GB free
 
   Disks:
-  DISK NAME  TOTAL  USED   FREE
-  /          97 GB  56 GB  36 GB
-  /boot      1 GB   0 GB   1 GB
+  MOUNT  TOTAL  USED   USAGE
+  /      97 GB  56 GB  58%
+  /boot  1 GB   0 GB   0%
 ```
 
 When targeting all hosts, a summary table is shown:
@@ -24,21 +24,28 @@ $ osapi client node status get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  UPTIME                          LOAD (1m)  MEMORY USED
-  server1   64 days, 11 hours, 20 minutes   1.83       19 GB / 31 GB
-  server2   12 days, 3 hours, 45 minutes    0.45       8 GB / 16 GB
+  HOSTNAME  STATUS  UPTIME                          LOAD  MEM
+  server1   ok      64 days, 11 hours, 20 minutes   1.83  19 GB / 31 GB
+  server2   ok      12 days, 3 hours, 45 minutes    0.45  8 GB / 16 GB
+
+  2 hosts: 2 ok
 ```
 
-When some hosts fail or are skipped, STATUS and ERROR columns are shown:
+When some hosts fail or are skipped:
 
 ```bash
 $ osapi client node status get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   UPTIME                         LOAD (1m)  MEMORY USED  ERROR
-  server1   ok       64 days, 11 hours, 20 minutes  1.83       19 GB / 31 GB
-  server2   skipped                                                           unsupported platform
+  HOSTNAME  STATUS  UPTIME                          LOAD  MEM
+  server1   ok      64 days, 11 hours, 20 minutes   1.83  19 GB / 31 GB
+  server2   skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 Target by label to query a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/sysctl/create.md
+++ b/docs/docs/sidebar/usage/cli/client/node/sysctl/create.md
@@ -11,8 +11,10 @@ $ osapi client node sysctl create --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY                   CHANGED
-  web-01    net.ipv4.ip_forward   true
+  HOSTNAME  STATUS   KEY                   CHANGED
+  web-01    changed  net.ipv4.ip_forward   true
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts at once:
@@ -23,13 +25,14 @@ $ osapi client node sysctl create --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY           CHANGED
-  web-01    vm.swappiness  true
-  web-02    vm.swappiness  true
+  HOSTNAME  STATUS   KEY            CHANGED
+  web-01    changed  vm.swappiness  true
+  web-02    changed  vm.swappiness  true
+
+  2 hosts: 2 changed
 ```
 
-When some hosts are skipped (e.g., macOS agents), STATUS and ERROR columns are
-added:
+When some hosts are skipped (e.g., macOS agents):
 
 ```bash
 $ osapi client node sysctl create --target _all \
@@ -37,9 +40,14 @@ $ osapi client node sysctl create --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   KEY           CHANGED  ERROR
-  web-01    ok       vm.swappiness  true
-  mac-01    skipped                          unsupported platform
+  HOSTNAME  STATUS   KEY            CHANGED
+  web-01    changed  vm.swappiness  true
+  mac-01    skip
+
+  2 hosts: 1 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/sysctl/delete.md
+++ b/docs/docs/sidebar/usage/cli/client/node/sysctl/delete.md
@@ -10,8 +10,10 @@ $ osapi client node sysctl delete --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY                   CHANGED
-  web-01    net.ipv4.ip_forward   true
+  HOSTNAME  STATUS   KEY                   CHANGED
+  web-01    changed  net.ipv4.ip_forward   true
+
+  1 host: 1 changed
 ```
 
 If the parameter does not exist, `changed: false` is returned:
@@ -22,8 +24,10 @@ $ osapi client node sysctl delete --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY                   CHANGED
-  web-01    net.ipv4.ip_forward   false
+  HOSTNAME  STATUS  KEY                   CHANGED
+  web-01    ok      net.ipv4.ip_forward   false
+
+  1 host: 1 ok
 ```
 
 Broadcast to all hosts:
@@ -34,9 +38,11 @@ $ osapi client node sysctl delete --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY           CHANGED
-  web-01    vm.swappiness  true
-  web-02    vm.swappiness  true
+  HOSTNAME  STATUS   KEY            CHANGED
+  web-01    changed  vm.swappiness  true
+  web-02    changed  vm.swappiness  true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/sysctl/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/sysctl/get.md
@@ -7,8 +7,10 @@ $ osapi client node sysctl get --target web-01 --key net.ipv4.ip_forward
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY                   VALUE
-  web-01    net.ipv4.ip_forward   1
+  HOSTNAME  STATUS  KEY                   VALUE
+  web-01    ok      net.ipv4.ip_forward   1
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -18,22 +20,28 @@ $ osapi client node sysctl get --target _all --key vm.swappiness
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY            VALUE
-  web-01    vm.swappiness  10
-  web-02    vm.swappiness  10
+  HOSTNAME  STATUS  KEY            VALUE
+  web-01    ok      vm.swappiness  10
+  web-02    ok      vm.swappiness  10
+
+  2 hosts: 2 ok
 ```
 
-When some hosts are skipped, STATUS and ERROR columns appear alongside data
-columns:
+When some hosts are skipped:
 
 ```bash
 $ osapi client node sysctl get --target _all --key vm.swappiness
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   ERROR                 KEY            VALUE
-  web-01    ok                              vm.swappiness  10
-  mac-01    skipped  unsupported platform
+  HOSTNAME  STATUS  KEY            VALUE
+  web-01    ok      vm.swappiness  10
+  mac-01    skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/sysctl/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/sysctl/list.md
@@ -7,10 +7,12 @@ $ osapi client node sysctl list --target web-01
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY                      VALUE
-  web-01    net.ipv4.ip_forward      1
-  web-01    vm.swappiness            10
-  web-01    kernel.panic             30
+  HOSTNAME  STATUS  KEY                      VALUE
+  web-01    ok      net.ipv4.ip_forward      1
+  web-01    ok      vm.swappiness            10
+  web-01    ok      kernel.panic             30
+
+  1 host: 1 ok
 ```
 
 Target all hosts to list parameters across the fleet:
@@ -20,11 +22,13 @@ $ osapi client node sysctl list --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY                  VALUE
-  web-01    net.ipv4.ip_forward  1
-  web-01    vm.swappiness        10
-  web-02    net.ipv4.ip_forward  1
-  web-02    vm.swappiness        10
+  HOSTNAME  STATUS  KEY                  VALUE
+  web-01    ok      net.ipv4.ip_forward  1
+  web-01    ok      vm.swappiness        10
+  web-02    ok      net.ipv4.ip_forward  1
+  web-02    ok      vm.swappiness        10
+
+  2 hosts: 2 ok
 ```
 
 Target by label to list parameters on a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/sysctl/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/sysctl/update.md
@@ -10,8 +10,10 @@ $ osapi client node sysctl update --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY                   CHANGED
-  web-01    net.ipv4.ip_forward   true
+  HOSTNAME  STATUS   KEY                   CHANGED
+  web-01    changed  net.ipv4.ip_forward   true
+
+  1 host: 1 changed
 ```
 
 If the parameter already has the requested value, `changed: false` is returned
@@ -23,8 +25,10 @@ $ osapi client node sysctl update --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY                   CHANGED
-  web-01    net.ipv4.ip_forward   false
+  HOSTNAME  STATUS  KEY                   CHANGED
+  web-01    ok      net.ipv4.ip_forward   false
+
+  1 host: 1 ok
 ```
 
 Broadcast to all hosts at once:
@@ -35,9 +39,11 @@ $ osapi client node sysctl update --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  KEY           CHANGED
-  web-01    vm.swappiness  true
-  web-02    vm.swappiness  true
+  HOSTNAME  STATUS   KEY            CHANGED
+  web-01    changed  vm.swappiness  true
+  web-02    changed  vm.swappiness  true
+
+  2 hosts: 2 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/timezone/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/timezone/get.md
@@ -36,8 +36,10 @@ osapi client node timezone get --json
 ```
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  TIMEZONE          UTC_OFFSET
-  web-01    America/New_York  -05:00
+  HOSTNAME  STATUS  TIMEZONE          UTC_OFFSET
+  web-01    ok      America/New_York  -05:00
+
+  1 host: 1 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/timezone/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/timezone/update.md
@@ -37,8 +37,10 @@ osapi client node timezone update --target web-01 \
 ```
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR
-  web-01    ok      true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/uptime/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/uptime/get.md
@@ -7,8 +7,10 @@ $ osapi client node uptime get
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  UPTIME
-  web-01    64 days, 11 hours, 20 minutes
+  HOSTNAME  STATUS  UPTIME
+  web-01    ok      64 days, 11 hours, 20 minutes
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -18,9 +20,11 @@ $ osapi client node uptime get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  UPTIME
-  server1   64 days, 11 hours, 20 minutes
-  server2   12 days, 3 hours, 45 minutes
+  HOSTNAME  STATUS  UPTIME
+  server1   ok      64 days, 11 hours, 20 minutes
+  server2   ok      12 days, 3 hours, 45 minutes
+
+  2 hosts: 2 ok
 ```
 
 When some hosts fail or are skipped:
@@ -30,9 +34,14 @@ $ osapi client node uptime get --target _all
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS   UPTIME                          ERROR
-  server1   ok       64 days, 11 hours, 20 minutes
-  server2   skipped                                  unsupported platform
+  HOSTNAME  STATUS  UPTIME
+  server1   ok      64 days, 11 hours, 20 minutes
+  server2   skip
+
+  2 hosts: 1 ok, 1 skipped
+
+  Details:
+  server2   unsupported platform
 ```
 
 Target by label to query a group of servers:

--- a/docs/docs/sidebar/usage/cli/client/node/user/create.md
+++ b/docs/docs/sidebar/usage/cli/client/node/user/create.md
@@ -8,8 +8,10 @@ $ osapi client node user create --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  NAME
-  web-01    ok      true            deploy
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     deploy
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts:
@@ -20,10 +22,15 @@ $ osapi client node user create --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR                 NAME
-  web-01    ok      true                            deploy
-  web-02    ok      true                            deploy
-  mac-01    skipped false    unsupported platform
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     deploy
+  web-02    changed  true     deploy
+  mac-01    skip
+
+  3 hosts: 2 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## Flags

--- a/docs/docs/sidebar/usage/cli/client/node/user/delete.md
+++ b/docs/docs/sidebar/usage/cli/client/node/user/delete.md
@@ -7,8 +7,10 @@ $ osapi client node user delete --target web-01 --name deploy
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  NAME
-  web-01    ok      true            deploy
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     deploy
+
+  1 host: 1 changed
 ```
 
 Broadcast to all hosts:
@@ -18,10 +20,15 @@ $ osapi client node user delete --target _all --name deploy
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR                 NAME
-  web-01    ok      true                            deploy
-  web-02    ok      true                            deploy
-  mac-01    skipped false    unsupported platform
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     deploy
+  web-02    changed  true     deploy
+  mac-01    skip
+
+  3 hosts: 2 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## Flags

--- a/docs/docs/sidebar/usage/cli/client/node/user/get.md
+++ b/docs/docs/sidebar/usage/cli/client/node/user/get.md
@@ -5,8 +5,10 @@ Get a specific user account by name:
 ```bash
 $ osapi client node user get --target web-01 --name deploy
 
-  HOSTNAME  NAME     UID   GID   HOME            SHELL        GROUPS       LOCKED
-  web-01    deploy   1001  1001  /home/deploy    /bin/bash     sudo,docker  no
+  HOSTNAME  STATUS  NAME     UID   HOME            SHELL      GROUPS
+  web-01    ok      deploy   1001  /home/deploy    /bin/bash   sudo,docker
+
+  1 host: 1 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/user/list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/user/list.md
@@ -5,9 +5,11 @@ List all user accounts on a target host:
 ```bash
 $ osapi client node user list --target web-01
 
-  HOSTNAME  NAME     UID   GID   HOME            SHELL        GROUPS       LOCKED
-  web-01    deploy   1001  1001  /home/deploy    /bin/bash     sudo,docker  no
-  web-01    app      1002  1002  /home/app       /bin/sh       users        no
+  HOSTNAME  STATUS  NAME     UID   HOME            SHELL      GROUPS
+  web-01    ok      deploy   1001  /home/deploy    /bin/bash   sudo,docker
+  web-01    ok      app      1002  /home/app       /bin/sh     users
+
+  1 host: 1 ok
 ```
 
 ## JSON Output

--- a/docs/docs/sidebar/usage/cli/client/node/user/password.md
+++ b/docs/docs/sidebar/usage/cli/client/node/user/password.md
@@ -8,8 +8,10 @@ $ osapi client node user password --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  NAME
-  web-01    ok      true            deploy
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     deploy
+
+  1 host: 1 changed
 ```
 
 The password is sent as plaintext and hashed by the agent using the system's
@@ -23,10 +25,15 @@ $ osapi client node user password --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR                 NAME
-  web-01    ok      true                            deploy
-  web-02    ok      true                            deploy
-  mac-01    skipped false    unsupported platform
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     deploy
+  web-02    changed  true     deploy
+  mac-01    skip
+
+  3 hosts: 2 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## Flags

--- a/docs/docs/sidebar/usage/cli/client/node/user/ssh-key-add.md
+++ b/docs/docs/sidebar/usage/cli/client/node/user/ssh-key-add.md
@@ -8,8 +8,10 @@ $ osapi client node user ssh-key add --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  CHANGED
-  web-01    true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
 The key is appended to the user's `~/.ssh/authorized_keys` file. If the file or
@@ -26,9 +28,11 @@ $ osapi client node user ssh-key add --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  CHANGED
-  web-01    true
-  web-02    true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+  web-02    changed  true
+
+  2 hosts: 2 changed
 ```
 
 ## Flags

--- a/docs/docs/sidebar/usage/cli/client/node/user/ssh-key-list.md
+++ b/docs/docs/sidebar/usage/cli/client/node/user/ssh-key-list.md
@@ -7,9 +7,11 @@ $ osapi client node user ssh-key list --target web-01 --name deploy
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  TYPE         FINGERPRINT      COMMENT
-  web-01    ssh-ed25519  SHA256:abc123...  user@laptop
-  web-01    ssh-rsa      SHA256:def456...  deploy-ci
+  HOSTNAME  STATUS  TYPE         FINGERPRINT      COMMENT
+  web-01    ok      ssh-ed25519  SHA256:abc123...  user@laptop
+  web-01    ok      ssh-rsa      SHA256:def456...  deploy-ci
+
+  1 host: 1 ok
 ```
 
 When targeting all hosts:
@@ -19,10 +21,12 @@ $ osapi client node user ssh-key list --target _all --name deploy
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  TYPE         FINGERPRINT      COMMENT
-  web-01    ssh-ed25519  SHA256:abc123...  user@laptop
-  web-02    ssh-ed25519  SHA256:abc123...  user@laptop
-  web-02    ssh-rsa      SHA256:ghi789...  deploy-prod
+  HOSTNAME  STATUS  TYPE         FINGERPRINT      COMMENT
+  web-01    ok      ssh-ed25519  SHA256:abc123...  user@laptop
+  web-02    ok      ssh-ed25519  SHA256:abc123...  user@laptop
+  web-02    ok      ssh-rsa      SHA256:ghi789...  deploy-prod
+
+  2 hosts: 2 ok
 ```
 
 Hosts with no authorized keys are omitted from the output. Skipped hosts (e.g.,

--- a/docs/docs/sidebar/usage/cli/client/node/user/ssh-key-remove.md
+++ b/docs/docs/sidebar/usage/cli/client/node/user/ssh-key-remove.md
@@ -8,8 +8,10 @@ $ osapi client node user ssh-key remove --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  CHANGED
-  web-01    true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+
+  1 host: 1 changed
 ```
 
 The key matching the given SHA256 fingerprint is removed from the user's
@@ -24,9 +26,11 @@ $ osapi client node user ssh-key remove --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  CHANGED
-  web-01    true
-  web-02    true
+  HOSTNAME  STATUS   CHANGED
+  web-01    changed  true
+  web-02    changed  true
+
+  2 hosts: 2 changed
 ```
 
 ## Flags

--- a/docs/docs/sidebar/usage/cli/client/node/user/update.md
+++ b/docs/docs/sidebar/usage/cli/client/node/user/update.md
@@ -8,8 +8,10 @@ $ osapi client node user update --target web-01 \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR  NAME
-  web-01    ok      true            deploy
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     deploy
+
+  1 host: 1 changed
 ```
 
 Lock or unlock an account:
@@ -30,10 +32,15 @@ $ osapi client node user update --target _all \
 
   Job ID: 550e8400-e29b-41d4-a716-446655440000
 
-  HOSTNAME  STATUS  CHANGED  ERROR                 NAME
-  web-01    ok      true                            deploy
-  web-02    ok      true                            deploy
-  mac-01    skipped false    unsupported platform
+  HOSTNAME  STATUS   CHANGED  NAME
+  web-01    changed  true     deploy
+  web-02    changed  true     deploy
+  mac-01    skip
+
+  3 hosts: 2 changed, 1 skipped
+
+  Details:
+  mac-01    unsupported platform
 ```
 
 ## Flags

--- a/docs/plans/cli-output-audit.md
+++ b/docs/plans/cli-output-audit.md
@@ -3,17 +3,17 @@
 ## Goal
 
 Standardize all CLI table output to fit within ~100 characters. Merge
-STATUS/CHANGED/ERROR into a single STATUS column. Show error details
-in a separate section below the table.
+STATUS/CHANGED/ERROR into a single STATUS column. Show error details in a
+separate section below the table.
 
 ## STATUS Column Values
 
-| Value     | Meaning                                   |
-| --------- | ----------------------------------------- |
-| `ok`      | Succeeded, no change needed               |
-| `changed` | Succeeded and modified system state       |
-| `skip`    | Agent can't perform (unsupported OS)      |
-| `err`     | Operation failed (details shown below)    |
+| Value     | Meaning                                |
+| --------- | -------------------------------------- |
+| `ok`      | Succeeded, no change needed            |
+| `changed` | Succeeded and modified system state    |
+| `skip`    | Agent can't perform (unsupported OS)   |
+| `err`     | Operation failed (details shown below) |
 
 ## Table Format
 
@@ -48,42 +48,42 @@ in a separate section below the table.
 
 ### Keep as-is (already compact)
 
-| Command | Columns | Est. |
-|---------|---------|------|
-| hostname get | (none — just HOSTNAME + STATUS) | ~40 |
-| uptime get | UPTIME | ~45 |
-| os get | DISTRIBUTION, VERSION | ~55 |
-| memory get | TOTAL, USED, FREE, USAGE | ~65 |
-| load get | LOAD (1m), LOAD (5m), LOAD (15m) | ~65 |
-| timezone get | TIMEZONE, UTC_OFFSET | ~55 |
-| sysctl get/list | KEY, VALUE | ~60 |
-| group get/list | NAME, GID, MEMBERS | ~60 |
-| certificate list | NAME, SOURCE | ~55 |
-| log source | SOURCE | ~45 |
+| Command          | Columns                          | Est. |
+| ---------------- | -------------------------------- | ---- |
+| hostname get     | (none — just HOSTNAME + STATUS)  | ~40  |
+| uptime get       | UPTIME                           | ~45  |
+| os get           | DISTRIBUTION, VERSION            | ~55  |
+| memory get       | TOTAL, USED, FREE, USAGE         | ~65  |
+| load get         | LOAD (1m), LOAD (5m), LOAD (15m) | ~65  |
+| timezone get     | TIMEZONE, UTC_OFFSET             | ~55  |
+| sysctl get/list  | KEY, VALUE                       | ~60  |
+| group get/list   | NAME, GID, MEMBERS               | ~60  |
+| certificate list | NAME, SOURCE                     | ~55  |
+| log source       | SOURCE                           | ~45  |
 
 ### Trim columns
 
-| Command | Current | Proposed | Dropped |
-|---------|---------|----------|---------|
-| hostname get | LABELS | (none) | LABELS (use node get) |
-| user list | NAME, UID, GID, HOME, SHELL, GROUPS, LOCKED | NAME, UID, HOME, SHELL, GROUPS | GID, LOCKED |
-| user get | NAME, UID, GID, HOME, SHELL, GROUPS, LOCKED | NAME, UID, HOME, SHELL, GROUPS | GID, LOCKED |
-| process list | PID, NAME, USER, STATE, CPU%, MEM%, COMMAND | PID, NAME, USER, STATE, CPU%, COMMAND | MEM% |
-| process get | PID, NAME, USER, STATE, CPU%, MEM%, COMMAND | PID, NAME, USER, STATE, CPU%, COMMAND | MEM% |
-| service get | NAME, STATUS, ENABLED, DESCRIPTION, PID | NAME, STATUS, ENABLED, DESCRIPTION | PID |
-| service list | NAME, STATUS, ENABLED, DESCRIPTION | NAME, STATUS, ENABLED | DESCRIPTION |
-| cron list | NAME, SOURCE, SCHEDULE, OBJECT, USER | NAME, SCHEDULE, OBJECT, USER | SOURCE |
-| ntp get | SYNCHRONIZED, STRATUM, OFFSET, SOURCE, SERVERS | SYNCHRONIZED, SOURCE, SERVERS | STRATUM, OFFSET |
-| ping | AVG RTT, MIN RTT, MAX RTT, PACKET LOSS, PACKETS RECEIVED | AVG RTT, MIN RTT, MAX RTT, LOSS | PACKETS RECEIVED |
-| docker list | ID, NAME, IMAGE, STATE, CREATED | NAME, IMAGE, STATE | ID, CREATED |
-| docker inspect | ID, NAME, IMAGE, ... | NAME, IMAGE, STATE | (trim to essentials) |
-| disk get | MOUNT, TOTAL, USED, FREE, USAGE | MOUNT, TOTAL, USED, USAGE | FREE |
-| log query/unit | TIMESTAMP, PRIORITY, UNIT, MESSAGE | TIMESTAMP, UNIT, MESSAGE | PRIORITY |
-| command exec/shell | STDOUT, STDERR, EXIT CODE, DURATION | EXIT CODE, STDOUT | STDERR (separate), DURATION |
-| status get | UPTIME, LOAD (1m), MEMORY USED | UPTIME, LOAD, MEM | shorten headers |
-| package list | NAME, VERSION, STATUS, SIZE | NAME, VERSION, STATUS | SIZE |
-| file status | PATH, STATUS, SHA256 | PATH, STATUS | SHA256 (use --json) |
-| ssh key list | TYPE, FINGERPRINT, COMMENT | TYPE, FINGERPRINT | COMMENT |
+| Command            | Current                                                  | Proposed                              | Dropped                     |
+| ------------------ | -------------------------------------------------------- | ------------------------------------- | --------------------------- |
+| hostname get       | LABELS                                                   | (none)                                | LABELS (use node get)       |
+| user list          | NAME, UID, GID, HOME, SHELL, GROUPS, LOCKED              | NAME, UID, HOME, SHELL, GROUPS        | GID, LOCKED                 |
+| user get           | NAME, UID, GID, HOME, SHELL, GROUPS, LOCKED              | NAME, UID, HOME, SHELL, GROUPS        | GID, LOCKED                 |
+| process list       | PID, NAME, USER, STATE, CPU%, MEM%, COMMAND              | PID, NAME, USER, STATE, CPU%, COMMAND | MEM%                        |
+| process get        | PID, NAME, USER, STATE, CPU%, MEM%, COMMAND              | PID, NAME, USER, STATE, CPU%, COMMAND | MEM%                        |
+| service get        | NAME, STATUS, ENABLED, DESCRIPTION, PID                  | NAME, STATUS, ENABLED, DESCRIPTION    | PID                         |
+| service list       | NAME, STATUS, ENABLED, DESCRIPTION                       | NAME, STATUS, ENABLED                 | DESCRIPTION                 |
+| cron list          | NAME, SOURCE, SCHEDULE, OBJECT, USER                     | NAME, SCHEDULE, OBJECT, USER          | SOURCE                      |
+| ntp get            | SYNCHRONIZED, STRATUM, OFFSET, SOURCE, SERVERS           | SYNCHRONIZED, SOURCE, SERVERS         | STRATUM, OFFSET             |
+| ping               | AVG RTT, MIN RTT, MAX RTT, PACKET LOSS, PACKETS RECEIVED | AVG RTT, MIN RTT, MAX RTT, LOSS       | PACKETS RECEIVED            |
+| docker list        | ID, NAME, IMAGE, STATE, CREATED                          | NAME, IMAGE, STATE                    | ID, CREATED                 |
+| docker inspect     | ID, NAME, IMAGE, ...                                     | NAME, IMAGE, STATE                    | (trim to essentials)        |
+| disk get           | MOUNT, TOTAL, USED, FREE, USAGE                          | MOUNT, TOTAL, USED, USAGE             | FREE                        |
+| log query/unit     | TIMESTAMP, PRIORITY, UNIT, MESSAGE                       | TIMESTAMP, UNIT, MESSAGE              | PRIORITY                    |
+| command exec/shell | STDOUT, STDERR, EXIT CODE, DURATION                      | EXIT CODE, STDOUT                     | STDERR (separate), DURATION |
+| status get         | UPTIME, LOAD (1m), MEMORY USED                           | UPTIME, LOAD, MEM                     | shorten headers             |
+| package list       | NAME, VERSION, STATUS, SIZE                              | NAME, VERSION, STATUS                 | SIZE                        |
+| file status        | PATH, STATUS, SHA256                                     | PATH, STATUS                          | SHA256 (use --json)         |
+| ssh key list       | TYPE, FINGERPRINT, COMMENT                               | TYPE, FINGERPRINT                     | COMMENT                     |
 
 ## Implementation Order
 

--- a/docs/plans/cli-output-audit.md
+++ b/docs/plans/cli-output-audit.md
@@ -1,0 +1,95 @@
+# CLI Output Audit — 100-char Width Target
+
+## Goal
+
+Standardize all CLI table output to fit within ~100 characters. Merge
+STATUS/CHANGED/ERROR into a single STATUS column. Show error details
+in a separate section below the table.
+
+## STATUS Column Values
+
+| Value     | Meaning                                   |
+| --------- | ----------------------------------------- |
+| `ok`      | Succeeded, no change needed               |
+| `changed` | Succeeded and modified system state       |
+| `skip`    | Agent can't perform (unsupported OS)      |
+| `err`     | Operation failed (details shown below)    |
+
+## Table Format
+
+```
+  Job ID: ...
+
+  HOSTNAME  STATUS   NAME      UID    HOME
+  nerd      ok       root      0      /root
+  nerd      ok       retr0h    1000   /home/retr0h
+  mac       skip
+
+  Errors:
+  mac  operation not supported on this OS family
+```
+
+## Core Changes
+
+### BuildBroadcastTable + BuildMutationTable
+
+- Always show HOSTNAME + STATUS
+- STATUS = `ok` | `changed` | `skip` | `err`
+- Remove ERROR column from table
+- Remove CHANGED column (merged into STATUS)
+- Return error list separately for rendering below table
+
+### PrintCompactTable
+
+- Accept optional errors section
+- Render errors below table when present
+
+## Per-Command Column Audit
+
+### Keep as-is (already compact)
+
+| Command | Columns | Est. |
+|---------|---------|------|
+| hostname get | (none — just HOSTNAME + STATUS) | ~40 |
+| uptime get | UPTIME | ~45 |
+| os get | DISTRIBUTION, VERSION | ~55 |
+| memory get | TOTAL, USED, FREE, USAGE | ~65 |
+| load get | LOAD (1m), LOAD (5m), LOAD (15m) | ~65 |
+| timezone get | TIMEZONE, UTC_OFFSET | ~55 |
+| sysctl get/list | KEY, VALUE | ~60 |
+| group get/list | NAME, GID, MEMBERS | ~60 |
+| certificate list | NAME, SOURCE | ~55 |
+| log source | SOURCE | ~45 |
+
+### Trim columns
+
+| Command | Current | Proposed | Dropped |
+|---------|---------|----------|---------|
+| hostname get | LABELS | (none) | LABELS (use node get) |
+| user list | NAME, UID, GID, HOME, SHELL, GROUPS, LOCKED | NAME, UID, HOME, SHELL, GROUPS | GID, LOCKED |
+| user get | NAME, UID, GID, HOME, SHELL, GROUPS, LOCKED | NAME, UID, HOME, SHELL, GROUPS | GID, LOCKED |
+| process list | PID, NAME, USER, STATE, CPU%, MEM%, COMMAND | PID, NAME, USER, STATE, CPU%, COMMAND | MEM% |
+| process get | PID, NAME, USER, STATE, CPU%, MEM%, COMMAND | PID, NAME, USER, STATE, CPU%, COMMAND | MEM% |
+| service get | NAME, STATUS, ENABLED, DESCRIPTION, PID | NAME, STATUS, ENABLED, DESCRIPTION | PID |
+| service list | NAME, STATUS, ENABLED, DESCRIPTION | NAME, STATUS, ENABLED | DESCRIPTION |
+| cron list | NAME, SOURCE, SCHEDULE, OBJECT, USER | NAME, SCHEDULE, OBJECT, USER | SOURCE |
+| ntp get | SYNCHRONIZED, STRATUM, OFFSET, SOURCE, SERVERS | SYNCHRONIZED, SOURCE, SERVERS | STRATUM, OFFSET |
+| ping | AVG RTT, MIN RTT, MAX RTT, PACKET LOSS, PACKETS RECEIVED | AVG RTT, MIN RTT, MAX RTT, LOSS | PACKETS RECEIVED |
+| docker list | ID, NAME, IMAGE, STATE, CREATED | NAME, IMAGE, STATE | ID, CREATED |
+| docker inspect | ID, NAME, IMAGE, ... | NAME, IMAGE, STATE | (trim to essentials) |
+| disk get | MOUNT, TOTAL, USED, FREE, USAGE | MOUNT, TOTAL, USED, USAGE | FREE |
+| log query/unit | TIMESTAMP, PRIORITY, UNIT, MESSAGE | TIMESTAMP, UNIT, MESSAGE | PRIORITY |
+| command exec/shell | STDOUT, STDERR, EXIT CODE, DURATION | EXIT CODE, STDOUT | STDERR (separate), DURATION |
+| status get | UPTIME, LOAD (1m), MEMORY USED | UPTIME, LOAD, MEM | shorten headers |
+| package list | NAME, VERSION, STATUS, SIZE | NAME, VERSION, STATUS | SIZE |
+| file status | PATH, STATUS, SHA256 | PATH, STATUS | SHA256 (use --json) |
+| ssh key list | TYPE, FINGERPRINT, COMMENT | TYPE, FINGERPRINT | COMMENT |
+
+## Implementation Order
+
+1. Rewrite `BuildBroadcastTable` — unified STATUS, separate errors
+2. Rewrite `BuildMutationTable` — same pattern (or merge into one)
+3. Update `PrintCompactTable` — render errors section
+4. Update tests for new table format
+5. Trim columns per command (one commit per domain group)
+6. Update CLI docs

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -49,3 +49,17 @@ func SetHostInfoFn(
 func ResetHostInfoFn() {
 	hostInfoFn = host.Info
 }
+
+// ExportStatusWeight exposes the private statusWeight function for testing.
+func ExportStatusWeight(
+	status string,
+) int {
+	return statusWeight(status)
+}
+
+// ExportResolveStatus exposes the private resolveStatus function for testing.
+func ExportResolveStatus(
+	r ResultRow,
+) string {
+	return resolveStatus(r)
+}

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -41,6 +41,9 @@ var (
 	Gray      = lipgloss.Color("245")
 	LightGray = lipgloss.Color("241")
 	White     = lipgloss.Color("15")
+	Red       = lipgloss.Color("196")
+	Yellow    = lipgloss.Color("226")
+	Green     = lipgloss.Color("82")
 	Teal      = lipgloss.Color("#06ffa5")
 )
 
@@ -55,12 +58,15 @@ var (
 
 // Section represents a header with its corresponding rows.
 type Section struct {
-	Title   string
-	Headers []string
-	Rows    [][]string
+	Title    string
+	Headers  []string
+	Rows     [][]string
+	Errors   []ErrorEntry
+	Duration string // e.g. "286ms" — shown in summary line
 }
 
-// ResultRow is a per-host broadcast result used by BuildBroadcastTable.
+// ResultRow is a per-host result used by BuildBroadcastTable and
+// BuildMutationTable.
 type ResultRow struct {
 	Hostname string
 	Status   string
@@ -69,123 +75,95 @@ type ResultRow struct {
 	Fields   []string
 }
 
-// BuildBroadcastTable builds headers and rows for a broadcast result table.
-// It prepends HOSTNAME to every row and conditionally inserts STATUS, CHANGED,
-// and ERROR columns when any result carries an error.
+// ErrorEntry is an error or skip reason from a host, rendered below the table.
+type ErrorEntry struct {
+	Hostname string
+	Message  string
+	Status   string // "err" or "skip"
+}
+
+// TableResult holds the output of BuildBroadcastTable / BuildMutationTable.
+type TableResult struct {
+	Headers []string
+	Rows    [][]string
+	Errors  []ErrorEntry
+}
+
+// resolveStatus computes the compact STATUS value from a ResultRow.
+// Values: ok, changed, skip, err.
+func resolveStatus(
+	r ResultRow,
+) string {
+	// Check skipped before error — skipped operations set an error
+	// message ("unsupported on this OS family") but are not failures.
+	if r.Status == "skipped" || r.Status == "skip" {
+		return "skip"
+	}
+
+	if r.Error != nil {
+		return "err"
+	}
+
+	if r.Changed != nil && *r.Changed {
+		return "changed"
+	}
+
+	return "ok"
+}
+
+// BuildBroadcastTable builds a TableResult for a broadcast response.
+// HOSTNAME and STATUS are always shown. Errors are collected for
+// rendering below the table by PrintCompactTable.
 func BuildBroadcastTable(
 	results []ResultRow,
 	fieldHeaders []string,
-) ([]string, [][]string) {
-	hasErrors := false
-	for _, r := range results {
-		if r.Error != nil {
-			hasErrors = true
-			break
-		}
-	}
-
-	hasChanged := false
-	for _, r := range results {
-		if r.Changed != nil {
-			hasChanged = true
-			break
-		}
-	}
-
-	var headers []string
-	headers = append(headers, "HOSTNAME")
-	if hasErrors {
-		headers = append(headers, "STATUS", "ERROR")
-	}
-	if hasChanged {
-		headers = append(headers, "CHANGED")
-	}
-	headers = append(headers, fieldHeaders...)
-
-	rows := make([][]string, 0, len(results))
-	for _, r := range results {
-		var row []string
-		row = append(row, r.Hostname)
-		if hasErrors {
-			status := r.Status
-			if status == "" {
-				status = "ok"
-			}
-			errMsg := ""
-			if r.Error != nil {
-				errMsg = *r.Error
-			}
-			row = append(row, status, errMsg)
-		}
-		if hasChanged {
-			changedStr := ""
-			if r.Changed != nil {
-				changedStr = fmt.Sprintf("%v", *r.Changed)
-			}
-			row = append(row, changedStr)
-		}
-		row = append(row, r.Fields...)
-		rows = append(rows, row)
-	}
-
-	return headers, rows
+) TableResult {
+	return buildTable(results, fieldHeaders)
 }
 
-// MutationResultRow is a per-host mutation result used by BuildMutationTable.
-type MutationResultRow struct {
-	Hostname string
-	Status   string
-	Changed  *bool
-	Error    *string
-	Fields   []string
-}
-
-// BuildMutationTable builds headers and rows for a mutation broadcast table.
-// Unlike BuildBroadcastTable, STATUS and ERROR columns are always shown because
-// mutation results carry an explicit status field.
+// BuildMutationTable builds a TableResult for a mutation response.
+// Uses the same unified STATUS column (ok/changed/skip/err).
 func BuildMutationTable(
-	results []MutationResultRow,
+	results []ResultRow,
 	fieldHeaders []string,
-) ([]string, [][]string) {
-	// Hide HOSTNAME when all results come from the same host.
-	multiHost := false
-	if len(results) > 1 {
-		first := results[0].Hostname
-		for _, r := range results[1:] {
-			if r.Hostname != first {
-				multiHost = true
-				break
-			}
-		}
-	}
+) TableResult {
+	return buildTable(results, fieldHeaders)
+}
 
-	headers := make([]string, 0, 4+len(fieldHeaders))
-	if multiHost {
-		headers = append(headers, "HOSTNAME")
-	}
-	headers = append(headers, "STATUS", "CHANGED", "ERROR")
+// buildTable is the shared implementation for broadcast and mutation tables.
+func buildTable(
+	results []ResultRow,
+	fieldHeaders []string,
+) TableResult {
+	headers := make([]string, 0, 2+len(fieldHeaders))
+	headers = append(headers, "HOSTNAME", "STATUS")
 	headers = append(headers, fieldHeaders...)
 
+	var errors []ErrorEntry
 	rows := make([][]string, 0, len(results))
+
 	for _, r := range results {
-		errMsg := ""
+		status := resolveStatus(r)
+
+		// Collect errors and skip reasons for rendering below the table.
 		if r.Error != nil {
-			errMsg = *r.Error
+			errors = append(errors, ErrorEntry{
+				Hostname: r.Hostname,
+				Message:  *r.Error,
+				Status:   status,
+			})
 		}
-		changedStr := ""
-		if r.Changed != nil {
-			changedStr = fmt.Sprintf("%v", *r.Changed)
-		}
-		row := make([]string, 0, 4+len(r.Fields))
-		if multiHost {
-			row = append(row, r.Hostname)
-		}
-		row = append(row, r.Status, changedStr, errMsg)
+
+		row := []string{r.Hostname, status}
 		row = append(row, r.Fields...)
 		rows = append(rows, row)
 	}
 
-	return headers, rows
+	return TableResult{
+		Headers: headers,
+		Rows:    rows,
+		Errors:  errors,
+	}
 }
 
 // BoolToSafeString converts a *bool to a string. Returns "" if nil.
@@ -302,6 +280,117 @@ func PrintCompactTable(
 			}
 			fmt.Println(line.String())
 		}
+
+		printSummary(section)
+		PrintErrors(section.Errors)
+	}
+}
+
+// printSummary renders a status summary line below the table.
+// Format: "2 hosts: 1 ok, 1 skipped in 286ms"
+func printSummary(
+	section Section,
+) {
+	// Count unique hostnames and their statuses from the rows.
+	// STATUS is always the second column (index 1).
+	hostStatuses := make(map[string]string)
+	for _, row := range section.Rows {
+		if len(row) >= 2 {
+			hostname := row[0]
+			status := row[1]
+			// Keep the "worst" status per host.
+			if cur, ok := hostStatuses[hostname]; !ok || statusWeight(status) > statusWeight(cur) {
+				hostStatuses[hostname] = status
+			}
+		}
+	}
+
+	// Also count error hosts not in the table.
+	for _, e := range section.Errors {
+		if _, ok := hostStatuses[e.Hostname]; !ok {
+			hostStatuses[e.Hostname] = "err"
+		}
+	}
+
+	totalHosts := len(hostStatuses)
+	if totalHosts == 0 {
+		return
+	}
+
+	counts := map[string]int{}
+	for _, status := range hostStatuses {
+		counts[status]++
+	}
+
+	greenStyle := lipgloss.NewStyle().Foreground(Green)
+	yellowStyle := lipgloss.NewStyle().Foreground(Yellow)
+	redStyle := lipgloss.NewStyle().Foreground(Red)
+	grayStyle := lipgloss.NewStyle().Foreground(Gray)
+
+	var parts []string
+	if n := counts["ok"]; n > 0 {
+		parts = append(parts, greenStyle.Render(fmt.Sprintf("%d ok", n)))
+	}
+	if n := counts["changed"]; n > 0 {
+		parts = append(parts, greenStyle.Render(fmt.Sprintf("%d changed", n)))
+	}
+	if n := counts["skip"]; n > 0 {
+		parts = append(parts, yellowStyle.Render(fmt.Sprintf("%d skipped", n)))
+	}
+	if n := counts["err"]; n > 0 {
+		parts = append(parts, redStyle.Render(fmt.Sprintf("%d failed", n)))
+	}
+
+	summary := fmt.Sprintf("%d hosts: %s", totalHosts, strings.Join(parts, ", "))
+	if section.Duration != "" {
+		summary += grayStyle.Render(fmt.Sprintf(" in %s", section.Duration))
+	}
+
+	fmt.Printf("\n  %s\n", summary)
+}
+
+// statusWeight returns a numeric weight for status ordering.
+// Higher = worse, used to pick the "worst" status per host.
+func statusWeight(
+	status string,
+) int {
+	switch status {
+	case "ok":
+		return 0
+	case "changed":
+		return 1
+	case "skip":
+		return 2
+	case "err":
+		return 3
+	default:
+		return 0
+	}
+}
+
+// PrintErrors renders error and skip entries below a table. Errors are
+// red, skips are yellow. Each entry shows hostname and message.
+func PrintErrors(
+	errors []ErrorEntry,
+) {
+	if len(errors) == 0 {
+		return
+	}
+
+	errStyle := lipgloss.NewStyle().Foreground(Red)
+	skipStyle := lipgloss.NewStyle().Foreground(Yellow)
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(Purple)
+
+	fmt.Printf("\n  %s\n", labelStyle.Render("Details:"))
+	for _, e := range errors {
+		style := errStyle
+		if e.Status == "skip" {
+			style = skipStyle
+		}
+		fmt.Printf("  %s  %s\n",
+			style.Render(e.Hostname),
+			style.Render(e.Message),
+		)
 	}
 }
 

--- a/internal/cli/ui_public_test.go
+++ b/internal/cli/ui_public_test.go
@@ -107,103 +107,103 @@ func (suite *UIPublicTestSuite) TestBuildBroadcastTable() {
 		wantRows     [][]string
 	}{
 		{
-			name:         "when no results returns hostname header only",
+			name:         "when no results returns hostname and status headers",
 			results:      []cli.ResultRow{},
 			fieldHeaders: nil,
-			wantHeaders:  []string{"HOSTNAME"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS"},
 			wantRows:     [][]string{},
 		},
 		{
-			name: "when all results succeed omits status and error columns",
+			name: "when all results succeed shows ok status",
 			results: []cli.ResultRow{
 				{Hostname: "web-01", Fields: []string{"val1"}},
 				{Hostname: "web-02", Fields: []string{"val2"}},
 			},
 			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"HOSTNAME", "DATA"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DATA"},
 			wantRows: [][]string{
-				{"web-01", "val1"},
-				{"web-02", "val2"},
+				{"web-01", "ok", "val1"},
+				{"web-02", "ok", "val2"},
 			},
 		},
 		{
-			name: "when some results have errors adds status and error columns",
+			name: "when some results have errors shows err status",
 			results: []cli.ResultRow{
 				{Hostname: "web-01", Status: "ok", Fields: []string{"val1"}},
 				{Hostname: "web-02", Status: "failed", Error: &errMsg, Fields: []string{""}},
 			},
 			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"HOSTNAME", "STATUS", "ERROR", "DATA"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DATA"},
 			wantRows: [][]string{
-				{"web-01", "ok", "", "val1"},
-				{"web-02", "failed", "connection refused", ""},
+				{"web-01", "ok", "val1"},
+				{"web-02", "err", ""},
 			},
 		},
 		{
-			name: "when status is empty defaults to ok",
-			results: []cli.ResultRow{
-				{Hostname: "web-01", Fields: []string{"val1"}},
-				{Hostname: "web-02", Status: "failed", Error: &errMsg, Fields: []string{""}},
-			},
-			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"HOSTNAME", "STATUS", "ERROR", "DATA"},
-			wantRows: [][]string{
-				{"web-01", "ok", "", "val1"},
-				{"web-02", "failed", "connection refused", ""},
-			},
-		},
-		{
-			name: "when skipped host shows skipped status",
+			name: "when skipped host shows skip status",
 			results: []cli.ResultRow{
 				{Hostname: "web-01", Status: "ok", Fields: []string{"val1"}},
-				{Hostname: "web-02", Status: "skipped", Error: &errMsg, Fields: []string{""}},
+				{Hostname: "web-02", Status: "skipped", Error: &errMsg},
 			},
 			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"HOSTNAME", "STATUS", "ERROR", "DATA"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DATA"},
 			wantRows: [][]string{
-				{"web-01", "ok", "", "val1"},
-				{"web-02", "skipped", "connection refused", ""},
+				{"web-01", "ok", "val1"},
+				{"web-02", "skip"},
 			},
 		},
 		{
-			name: "when single host shows hostname column",
+			name: "when skipped host with fields is included in rows",
+			results: []cli.ResultRow{
+				{Hostname: "web-01", Status: "ok", Fields: []string{"val1"}},
+				{Hostname: "web-02", Status: "skipped", Fields: []string{"partial"}},
+			},
+			fieldHeaders: []string{"DATA"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DATA"},
+			wantRows: [][]string{
+				{"web-01", "ok", "val1"},
+				{"web-02", "skip", "partial"},
+			},
+		},
+		{
+			name: "when single host shows hostname and status columns",
 			results: []cli.ResultRow{
 				{Hostname: "web-01", Fields: []string{"val1"}},
 			},
 			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"HOSTNAME", "DATA"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DATA"},
 			wantRows: [][]string{
-				{"web-01", "val1"},
+				{"web-01", "ok", "val1"},
 			},
 		},
 		{
-			name: "when all results have errors all show failed",
+			name: "when all results have errors shows err status",
 			results: []cli.ResultRow{
 				{Hostname: "web-01", Status: "failed", Error: &errMsg, Fields: []string{""}},
 				{Hostname: "web-02", Status: "failed", Error: &errMsg, Fields: []string{""}},
 			},
 			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"HOSTNAME", "STATUS", "ERROR", "DATA"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DATA"},
 			wantRows: [][]string{
-				{"web-01", "failed", "connection refused", ""},
-				{"web-02", "failed", "connection refused", ""},
+				{"web-01", "err", ""},
+				{"web-02", "err", ""},
 			},
 		},
 		{
-			name: "when changed is set adds changed column",
+			name: "when changed is true shows changed status",
 			results: []cli.ResultRow{
 				{Hostname: "web-01", Changed: boolPtr(true), Fields: []string{"val1"}},
 				{Hostname: "web-02", Changed: boolPtr(false), Fields: []string{"val2"}},
 			},
 			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"HOSTNAME", "CHANGED", "DATA"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DATA"},
 			wantRows: [][]string{
-				{"web-01", "true", "val1"},
-				{"web-02", "false", "val2"},
+				{"web-01", "changed", "val1"},
+				{"web-02", "ok", "val2"},
 			},
 		},
 		{
-			name: "when changed and errors both present shows all columns",
+			name: "when changed and errors both present shows all rows",
 			results: []cli.ResultRow{
 				{
 					Hostname: "web-01",
@@ -220,33 +220,33 @@ func (suite *UIPublicTestSuite) TestBuildBroadcastTable() {
 				},
 			},
 			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"HOSTNAME", "STATUS", "ERROR", "CHANGED", "DATA"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DATA"},
 			wantRows: [][]string{
-				{"web-01", "ok", "", "true", "val1"},
-				{"web-02", "failed", "connection refused", "false", ""},
+				{"web-01", "changed", "val1"},
+				{"web-02", "err", ""},
 			},
 		},
 		{
-			name: "when only some results have changed shows column with empty for nil",
+			name: "when no field headers shows only hostname and status",
 			results: []cli.ResultRow{
-				{Hostname: "web-01", Changed: boolPtr(true), Fields: []string{"val1"}},
-				{Hostname: "web-02", Fields: []string{"val2"}},
+				{Hostname: "web-01", Changed: boolPtr(true)},
+				{Hostname: "web-02"},
 			},
-			fieldHeaders: []string{"DATA"},
-			wantHeaders:  []string{"HOSTNAME", "CHANGED", "DATA"},
+			fieldHeaders: nil,
+			wantHeaders:  []string{"HOSTNAME", "STATUS"},
 			wantRows: [][]string{
-				{"web-01", "true", "val1"},
-				{"web-02", "", "val2"},
+				{"web-01", "changed"},
+				{"web-02", "ok"},
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
-			headers, rows := cli.BuildBroadcastTable(tc.results, tc.fieldHeaders)
+			tr := cli.BuildBroadcastTable(tc.results, tc.fieldHeaders)
 
-			assert.Equal(suite.T(), tc.wantHeaders, headers)
-			assert.Equal(suite.T(), tc.wantRows, rows)
+			assert.Equal(suite.T(), tc.wantHeaders, tr.Headers)
+			assert.Equal(suite.T(), tc.wantRows, tr.Rows)
 		})
 	}
 }
@@ -292,89 +292,246 @@ func (suite *UIPublicTestSuite) TestBuildMutationTable() {
 
 	tests := []struct {
 		name         string
-		results      []cli.MutationResultRow
+		results      []cli.ResultRow
 		fieldHeaders []string
 		wantHeaders  []string
 		wantRows     [][]string
 	}{
 		{
-			name:         "when no results returns empty",
-			results:      []cli.MutationResultRow{},
+			name:         "when no results returns hostname and status headers",
+			results:      []cli.ResultRow{},
 			fieldHeaders: nil,
-			wantHeaders:  []string{"STATUS", "CHANGED", "ERROR"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS"},
 			wantRows:     [][]string{},
 		},
 		{
-			name: "when all succeed shows ok status with empty error",
-			results: []cli.MutationResultRow{
+			name: "when all succeed shows ok status",
+			results: []cli.ResultRow{
 				{Hostname: "web-01", Status: "ok"},
 				{Hostname: "web-02", Status: "ok"},
 			},
 			fieldHeaders: nil,
-			wantHeaders:  []string{"HOSTNAME", "STATUS", "CHANGED", "ERROR"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS"},
 			wantRows: [][]string{
-				{"web-01", "ok", "", ""},
-				{"web-02", "ok", "", ""},
+				{"web-01", "ok"},
+				{"web-02", "ok"},
 			},
 		},
 		{
-			name: "when some fail shows error message",
-			results: []cli.MutationResultRow{
+			name: "when some fail shows err status",
+			results: []cli.ResultRow{
 				{Hostname: "web-01", Status: "ok"},
 				{Hostname: "web-02", Status: "failed", Error: &errMsg},
 			},
 			fieldHeaders: nil,
-			wantHeaders:  []string{"HOSTNAME", "STATUS", "CHANGED", "ERROR"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS"},
 			wantRows: [][]string{
-				{"web-01", "ok", "", ""},
-				{"web-02", "failed", "", "interface not found"},
+				{"web-01", "ok"},
+				{"web-02", "err"},
 			},
 		},
 		{
-			name: "when single host hides hostname column",
-			results: []cli.MutationResultRow{
+			name: "when single host shows hostname and status",
+			results: []cli.ResultRow{
 				{Hostname: "web-01", Status: "ok", Fields: []string{"extra"}},
 			},
 			fieldHeaders: []string{"DETAIL"},
-			wantHeaders:  []string{"STATUS", "CHANGED", "ERROR", "DETAIL"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DETAIL"},
 			wantRows: [][]string{
-				{"ok", "", "", "extra"},
+				{"web-01", "ok", "extra"},
 			},
 		},
 		{
-			name: "when changed is true shows true",
-			results: []cli.MutationResultRow{
+			name: "when changed is true shows changed status",
+			results: []cli.ResultRow{
 				{Hostname: "web-01", Status: "ok", Changed: boolPtr(true)},
 				{Hostname: "web-02", Status: "ok", Changed: boolPtr(true)},
 			},
 			fieldHeaders: nil,
-			wantHeaders:  []string{"HOSTNAME", "STATUS", "CHANGED", "ERROR"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS"},
 			wantRows: [][]string{
-				{"web-01", "ok", "true", ""},
-				{"web-02", "ok", "true", ""},
+				{"web-01", "changed"},
+				{"web-02", "changed"},
 			},
 		},
 		{
-			name: "when changed is false shows false",
-			results: []cli.MutationResultRow{
+			name: "when changed is false shows ok status",
+			results: []cli.ResultRow{
 				{Hostname: "web-01", Status: "ok", Changed: boolPtr(false)},
 				{Hostname: "web-02", Status: "ok", Changed: boolPtr(false)},
 			},
 			fieldHeaders: nil,
-			wantHeaders:  []string{"HOSTNAME", "STATUS", "CHANGED", "ERROR"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS"},
 			wantRows: [][]string{
-				{"web-01", "ok", "false", ""},
-				{"web-02", "ok", "false", ""},
+				{"web-01", "ok"},
+				{"web-02", "ok"},
+			},
+		},
+		{
+			name: "when field headers provided includes them after status",
+			results: []cli.ResultRow{
+				{Hostname: "web-01", Changed: boolPtr(true), Fields: []string{"val1"}},
+				{Hostname: "web-02", Fields: []string{"val2"}},
+			},
+			fieldHeaders: []string{"DATA"},
+			wantHeaders:  []string{"HOSTNAME", "STATUS", "DATA"},
+			wantRows: [][]string{
+				{"web-01", "changed", "val1"},
+				{"web-02", "ok", "val2"},
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
-			headers, rows := cli.BuildMutationTable(tc.results, tc.fieldHeaders)
+			tr := cli.BuildMutationTable(tc.results, tc.fieldHeaders)
 
-			assert.Equal(suite.T(), tc.wantHeaders, headers)
-			assert.Equal(suite.T(), tc.wantRows, rows)
+			assert.Equal(suite.T(), tc.wantHeaders, tr.Headers)
+			assert.Equal(suite.T(), tc.wantRows, tr.Rows)
+		})
+	}
+}
+
+func (suite *UIPublicTestSuite) TestBuildBroadcastTableResult() {
+	errMsg := "connection refused"
+	skipMsg := "unsupported"
+
+	tests := []struct {
+		name        string
+		results     []cli.ResultRow
+		fieldHdrs   []string
+		wantHeaders []string
+		wantRows    [][]string
+		wantErrors  []cli.ErrorEntry
+	}{
+		{
+			name: "when errors exist they appear in errors field",
+			results: []cli.ResultRow{
+				{Hostname: "web-01", Fields: []string{"val1"}},
+				{Hostname: "web-02", Error: &errMsg, Fields: []string{""}},
+			},
+			fieldHdrs:   []string{"DATA"},
+			wantHeaders: []string{"HOSTNAME", "STATUS", "DATA"},
+			wantRows: [][]string{
+				{"web-01", "ok", "val1"},
+				{"web-02", "err", ""},
+			},
+			wantErrors: []cli.ErrorEntry{
+				{Hostname: "web-02", Message: "connection refused", Status: "err"},
+			},
+		},
+		{
+			name: "when no errors the errors field is nil",
+			results: []cli.ResultRow{
+				{Hostname: "web-01", Fields: []string{"val1"}},
+				{Hostname: "web-02", Fields: []string{"val2"}},
+			},
+			fieldHdrs:   []string{"DATA"},
+			wantHeaders: []string{"HOSTNAME", "STATUS", "DATA"},
+			wantRows: [][]string{
+				{"web-01", "ok", "val1"},
+				{"web-02", "ok", "val2"},
+			},
+			wantErrors: nil,
+		},
+		{
+			name: "when skipped host without fields appears in errors",
+			results: []cli.ResultRow{
+				{Hostname: "web-01", Fields: []string{"val1"}},
+				{Hostname: "web-02", Status: "skipped", Error: &skipMsg},
+			},
+			fieldHdrs:   []string{"DATA"},
+			wantHeaders: []string{"HOSTNAME", "STATUS", "DATA"},
+			wantRows: [][]string{
+				{"web-01", "ok", "val1"},
+				{"web-02", "skip"},
+			},
+			wantErrors: []cli.ErrorEntry{
+				{Hostname: "web-02", Message: "unsupported", Status: "skip"},
+			},
+		},
+		{
+			name: "when multiple errors collects all",
+			results: []cli.ResultRow{
+				{Hostname: "web-01", Error: &errMsg},
+				{Hostname: "web-02", Error: &skipMsg},
+				{Hostname: "web-03", Fields: []string{"ok"}},
+			},
+			fieldHdrs:   []string{"DATA"},
+			wantHeaders: []string{"HOSTNAME", "STATUS", "DATA"},
+			wantRows: [][]string{
+				{"web-01", "err"},
+				{"web-02", "err"},
+				{"web-03", "ok", "ok"},
+			},
+			wantErrors: []cli.ErrorEntry{
+				{Hostname: "web-01", Message: "connection refused", Status: "err"},
+				{Hostname: "web-02", Message: "unsupported", Status: "err"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			result := cli.BuildBroadcastTable(tc.results, tc.fieldHdrs)
+
+			assert.Equal(suite.T(), tc.wantHeaders, result.Headers)
+			assert.Equal(suite.T(), tc.wantRows, result.Rows)
+			assert.Equal(suite.T(), tc.wantErrors, result.Errors)
+		})
+	}
+}
+
+func (suite *UIPublicTestSuite) TestBuildMutationTableResult() {
+	errMsg := "permission denied"
+
+	tests := []struct {
+		name        string
+		results     []cli.ResultRow
+		fieldHdrs   []string
+		wantHeaders []string
+		wantRows    [][]string
+		wantErrors  []cli.ErrorEntry
+	}{
+		{
+			name: "when mutation errors exist they appear in errors field",
+			results: []cli.ResultRow{
+				{Hostname: "web-01", Changed: boolPtr(true)},
+				{Hostname: "web-02", Error: &errMsg},
+			},
+			fieldHdrs:   nil,
+			wantHeaders: []string{"HOSTNAME", "STATUS"},
+			wantRows: [][]string{
+				{"web-01", "changed"},
+				{"web-02", "err"},
+			},
+			wantErrors: []cli.ErrorEntry{
+				{Hostname: "web-02", Message: "permission denied", Status: "err"},
+			},
+		},
+		{
+			name: "when no mutation errors the errors field is nil",
+			results: []cli.ResultRow{
+				{Hostname: "web-01", Changed: boolPtr(true)},
+				{Hostname: "web-02", Changed: boolPtr(false)},
+			},
+			fieldHdrs:   nil,
+			wantHeaders: []string{"HOSTNAME", "STATUS"},
+			wantRows: [][]string{
+				{"web-01", "changed"},
+				{"web-02", "ok"},
+			},
+			wantErrors: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			result := cli.BuildMutationTable(tc.results, tc.fieldHdrs)
+
+			assert.Equal(suite.T(), tc.wantHeaders, result.Headers)
+			assert.Equal(suite.T(), tc.wantRows, result.Rows)
+			assert.Equal(suite.T(), tc.wantErrors, result.Errors)
 		})
 	}
 }

--- a/internal/cli/ui_public_test.go
+++ b/internal/cli/ui_public_test.go
@@ -1190,3 +1190,242 @@ func (suite *UIPublicTestSuite) TestDisplayJobDetail() {
 		})
 	}
 }
+
+func (suite *UIPublicTestSuite) TestStatusWeight() {
+	tests := []struct {
+		name   string
+		status string
+		want   int
+	}{
+		{name: "when ok returns 0", status: "ok", want: 0},
+		{name: "when changed returns 1", status: "changed", want: 1},
+		{name: "when skip returns 2", status: "skip", want: 2},
+		{name: "when err returns 3", status: "err", want: 3},
+		{name: "when unknown returns 0", status: "unknown", want: 0},
+		{name: "when empty returns 0", status: "", want: 0},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			got := cli.ExportStatusWeight(tc.status)
+			assert.Equal(suite.T(), tc.want, got)
+		})
+	}
+}
+
+func (suite *UIPublicTestSuite) TestResolveStatus() {
+	errMsg := "failed"
+
+	tests := []struct {
+		name string
+		row  cli.ResultRow
+		want string
+	}{
+		{
+			name: "when no error and no change returns ok",
+			row:  cli.ResultRow{Hostname: "h1"},
+			want: "ok",
+		},
+		{
+			name: "when changed true returns changed",
+			row:  cli.ResultRow{Hostname: "h1", Changed: boolPtr(true)},
+			want: "changed",
+		},
+		{
+			name: "when changed false returns ok",
+			row:  cli.ResultRow{Hostname: "h1", Changed: boolPtr(false)},
+			want: "ok",
+		},
+		{
+			name: "when error returns err",
+			row:  cli.ResultRow{Hostname: "h1", Error: &errMsg},
+			want: "err",
+		},
+		{
+			name: "when status skipped returns skip even with error",
+			row:  cli.ResultRow{Hostname: "h1", Status: "skipped", Error: &errMsg},
+			want: "skip",
+		},
+		{
+			name: "when status skip returns skip",
+			row:  cli.ResultRow{Hostname: "h1", Status: "skip"},
+			want: "skip",
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			got := cli.ExportResolveStatus(tc.row)
+			assert.Equal(suite.T(), tc.want, got)
+		})
+	}
+}
+
+func (suite *UIPublicTestSuite) TestPrintSummary() {
+	tests := []struct {
+		name         string
+		section      cli.Section
+		validateFunc func(output string)
+	}{
+		{
+			name: "when mixed statuses shows counts",
+			section: cli.Section{
+				Rows: [][]string{
+					{"web-01", "ok", "val"},
+					{"web-02", "skip"},
+					{"web-03", "err"},
+				},
+			},
+			validateFunc: func(output string) {
+				assert.Contains(suite.T(), output, "3 hosts:")
+				assert.Contains(suite.T(), output, "1 ok")
+				assert.Contains(suite.T(), output, "1 skipped")
+				assert.Contains(suite.T(), output, "1 failed")
+			},
+		},
+		{
+			name: "when all ok shows only ok count",
+			section: cli.Section{
+				Rows: [][]string{
+					{"web-01", "ok", "val"},
+					{"web-02", "ok", "val"},
+				},
+			},
+			validateFunc: func(output string) {
+				assert.Contains(suite.T(), output, "2 hosts:")
+				assert.Contains(suite.T(), output, "2 ok")
+			},
+		},
+		{
+			name: "when changed shows changed count",
+			section: cli.Section{
+				Rows: [][]string{
+					{"web-01", "changed"},
+					{"web-02", "ok"},
+				},
+			},
+			validateFunc: func(output string) {
+				assert.Contains(suite.T(), output, "2 hosts:")
+				assert.Contains(suite.T(), output, "1 changed")
+				assert.Contains(suite.T(), output, "1 ok")
+			},
+		},
+		{
+			name: "when duration set shows duration",
+			section: cli.Section{
+				Duration: "286ms",
+				Rows: [][]string{
+					{"web-01", "ok"},
+				},
+			},
+			validateFunc: func(output string) {
+				assert.Contains(suite.T(), output, "286ms")
+			},
+		},
+		{
+			name: "when no rows does not print summary line",
+			section: cli.Section{
+				Rows: [][]string{},
+			},
+			validateFunc: func(output string) {
+				assert.NotContains(suite.T(), output, "hosts:")
+			},
+		},
+		{
+			name: "when error host not in rows counts from errors",
+			section: cli.Section{
+				Rows: [][]string{
+					{"web-01", "ok"},
+				},
+				Errors: []cli.ErrorEntry{
+					{Hostname: "web-02", Message: "timeout", Status: "err"},
+				},
+			},
+			validateFunc: func(output string) {
+				assert.Contains(suite.T(), output, "2 hosts:")
+				assert.Contains(suite.T(), output, "1 ok")
+				assert.Contains(suite.T(), output, "1 failed")
+			},
+		},
+		{
+			name: "when same host has multiple rows uses worst status",
+			section: cli.Section{
+				Rows: [][]string{
+					{"web-01", "ok", "val1"},
+					{"web-01", "err"},
+				},
+			},
+			validateFunc: func(output string) {
+				assert.Contains(suite.T(), output, "1 hosts:")
+				assert.Contains(suite.T(), output, "1 failed")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			output := captureStdout(func() {
+				cli.PrintCompactTable([]cli.Section{tc.section})
+			})
+			tc.validateFunc(output)
+		})
+	}
+}
+
+func (suite *UIPublicTestSuite) TestPrintErrors() {
+	tests := []struct {
+		name         string
+		errors       []cli.ErrorEntry
+		validateFunc func(output string)
+	}{
+		{
+			name:   "when no errors prints nothing",
+			errors: nil,
+			validateFunc: func(output string) {
+				assert.Empty(suite.T(), output)
+			},
+		},
+		{
+			name: "when error shows red details",
+			errors: []cli.ErrorEntry{
+				{Hostname: "web-01", Message: "connection refused", Status: "err"},
+			},
+			validateFunc: func(output string) {
+				assert.Contains(suite.T(), output, "Details:")
+				assert.Contains(suite.T(), output, "web-01")
+				assert.Contains(suite.T(), output, "connection refused")
+			},
+		},
+		{
+			name: "when skip shows details",
+			errors: []cli.ErrorEntry{
+				{Hostname: "mac-01", Message: "unsupported OS", Status: "skip"},
+			},
+			validateFunc: func(output string) {
+				assert.Contains(suite.T(), output, "Details:")
+				assert.Contains(suite.T(), output, "mac-01")
+				assert.Contains(suite.T(), output, "unsupported OS")
+			},
+		},
+		{
+			name: "when multiple entries shows all",
+			errors: []cli.ErrorEntry{
+				{Hostname: "web-01", Message: "timeout", Status: "err"},
+				{Hostname: "mac-01", Message: "unsupported", Status: "skip"},
+			},
+			validateFunc: func(output string) {
+				assert.Contains(suite.T(), output, "web-01")
+				assert.Contains(suite.T(), output, "mac-01")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			output := captureStdout(func() {
+				cli.PrintErrors(tc.errors)
+			})
+			tc.validateFunc(output)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Rewrite CLI table output for consistency and compactness:

- **Unified STATUS column**: `ok` / `changed` / `skip` / `err` replaces the old separate STATUS, CHANGED, and ERROR columns
- **Summary line**: color-coded host count below every table (e.g., "2 hosts: 1 ok, 1 skipped")
- **Details section**: errors and skip reasons shown below the summary in red/yellow
- **Column trimming**: 20 commands trimmed to fit ~100 char width
- **MutationResultRow removed**: merged into ResultRow

## Example output

```
  HOSTNAME  STATUS  MOUNT    TOTAL     USED      USAGE
  nerd      ok      /        97.9 GB   61.3 GB   63%
  nerd      ok      /boot    1.9 GB    191.6 MB  10%
  mac       skip

  2 hosts: 1 ok, 1 skipped

  Details:
  mac  operation not supported on this OS family
```

## Test plan

- [x] Build clean
- [x] Lint clean
- [x] CLI tests pass
- [x] Real output verified (disk, process, user, hostname)
- [x] Verify all commands show correct columns
- [x] Verify summary line appears on all commands

🤖 Generated with [Claude Code](https://claude.ai/code)