### PR TITLE
feat: report UI status in controller health sub-components

### DIFF
--- a/cmd/controller_setup.go
+++ b/cmd/controller_setup.go
@@ -880,6 +880,7 @@ func buildControllerSubComponents() map[string]job.SubComponentInfo {
 			Status: enabledOrDisabled(appConfig.Controller.Notifications.Enabled),
 		},
 		"controller.tracing": {Status: enabledOrDisabled(appConfig.Telemetry.Tracing.Enabled)},
+		"controller.ui":      {Status: enabledOrDisabled(appConfig.Controller.UI.UIEnabled())},
 	}
 }
 


### PR DESCRIPTION
## Summary

Add `controller.ui` to the controller's sub-component health map so the
dashboard and CLI health status show whether the embedded UI is enabled
or disabled.

Shows as `ok` when `controller.ui.enabled: true` (default), `disabled`
when set to `false`.

## Test plan

- [x] Health status shows `controller.ui: ok` when UI enabled
- [x] Health status shows `controller.ui: disabled` when UI disabled
- [x] Dashboard renders the UI component with green/gray dot

🤖 Generated with [Claude Code](https://claude.ai/code)