### PR TITLE
feat: limit agent labels to 5 with validation

### DIFF
--- a/docs/docs/sidebar/architecture/job-architecture.md
+++ b/docs/docs/sidebar/architecture/job-architecture.md
@@ -199,6 +199,17 @@ receive the message (broadcast within the label group). Label keys must match
 `[a-zA-Z0-9_-]+`, and each dot-separated segment of the value must match the
 same pattern.
 
+### Label Limits
+
+Agents support up to **5 labels**. Each label creates NATS JetStream consumers
+for every prefix level of its hierarchical value (query + modify). For example,
+one label `group: web.dev.us-east` creates 6 consumers (3 prefix levels × 2
+operation types). With 5 labels averaging 3 levels each, an agent creates ~36
+consumers total (30 label + 6 base).
+
+At fleet scale (1000+ agents), use an external NATS cluster rather than the
+embedded server to handle the consumer count efficiently.
+
 ## Supported Operations
 
 Browse `internal/agent/processor_*.go` for the current operation list.

--- a/docs/docs/sidebar/usage/configuration.md
+++ b/docs/docs/sidebar/usage/configuration.md
@@ -520,8 +520,9 @@ agent:
   hostname: ''
   # Maximum number of concurrent jobs to process.
   max_jobs: 10
-  # Key-value labels for label-based routing.
+  # Key-value labels for label-based routing (max 5).
   # Values can be hierarchical with dot separators.
+  # Each label creates NATS consumers for prefix matching.
   # See Job System Architecture for details.
   labels:
     group: 'web.dev.us-east'
@@ -730,7 +731,7 @@ When enabled, the port also serves `/health` (liveness) and `/health/ready`
 | `conditions.disk_pressure_threshold`       | int               | Disk pressure threshold percent (default 90)               |
 | `process_conditions.memory_pressure_bytes` | int64             | Process RSS threshold in bytes (0 = disabled)              |
 | `process_conditions.high_cpu_percent`      | float             | Process CPU usage threshold as a percentage (0 = disabled) |
-| `labels`                                   | map[string]string | Key-value pairs for label-based routing                    |
+| `labels`                                   | map[string]string | Key-value pairs for label-based routing (max 5)            |
 | `metrics.enabled`                          | bool              | Enable the metrics server (default: true)                  |
 | `metrics.port`                             | int               | Port the metrics server listens on (default: 9091)         |
 | `privilege_escalation.enabled`             | bool              | Activate sudo and capability checks (default false)        |

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -41,9 +41,9 @@ var (
 	Gray      = lipgloss.Color("245")
 	LightGray = lipgloss.Color("241")
 	White     = lipgloss.Color("15")
-	Red       = lipgloss.Color("196")
-	Yellow    = lipgloss.Color("226")
-	Green     = lipgloss.Color("82")
+	Red       = lipgloss.Color("#ef4444") // matches UI --color-status-error
+	Yellow    = lipgloss.Color("222")     // warm amber
+	Green     = lipgloss.Color("#67ea94") // matches UI --color-status-ready
 	Teal      = lipgloss.Color("#06ffa5")
 )
 
@@ -381,6 +381,14 @@ func PrintErrors(
 	skipStyle := lipgloss.NewStyle().Foreground(Yellow)
 	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(Purple)
 
+	// Find longest hostname for alignment.
+	maxHost := 0
+	for _, e := range errors {
+		if len(e.Hostname) > maxHost {
+			maxHost = len(e.Hostname)
+		}
+	}
+
 	fmt.Printf("\n  %s\n", labelStyle.Render("Details:"))
 	for _, e := range errors {
 		style := errStyle
@@ -388,7 +396,7 @@ func PrintErrors(
 			style = skipStyle
 		}
 		fmt.Printf("  %s  %s\n",
-			style.Render(e.Hostname),
+			style.Render(fmt.Sprintf("%-*s", maxHost, e.Hostname)),
 			style.Render(e.Message),
 		)
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -380,7 +380,7 @@ type AgentConfig struct {
 	// Labels are key-value pairs for label-based routing (e.g., role: web, env: prod).
 	// Maximum 5 labels per agent — each label creates multiple NATS consumers
 	// for hierarchical prefix matching.
-	Labels map[string]string `mapstructure:"labels" validate:"max=5"`
+	Labels map[string]string `mapstructure:"labels"                         validate:"max=5"`
 	// Conditions holds threshold settings for node condition evaluation.
 	Conditions AgentConditions `mapstructure:"conditions,omitempty"`
 	// ProcessConditions holds threshold settings for process-level condition evaluation.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -378,7 +378,9 @@ type AgentConfig struct {
 	// MaxJobs maximum number of concurrent jobs to process.
 	MaxJobs int `mapstructure:"max_jobs"                       validate:"min=1"`
 	// Labels are key-value pairs for label-based routing (e.g., role: web, env: prod).
-	Labels map[string]string `mapstructure:"labels"`
+	// Maximum 5 labels per agent — each label creates multiple NATS consumers
+	// for hierarchical prefix matching.
+	Labels map[string]string `mapstructure:"labels" validate:"max=5"`
 	// Conditions holds threshold settings for node condition evaluation.
 	Conditions AgentConditions `mapstructure:"conditions,omitempty"`
 	// ProcessConditions holds threshold settings for process-level condition evaluation.


### PR DESCRIPTION
## Summary

- Add `validate:"max=5"` on agent Labels config to prevent excessive NATS consumer creation
- Document label limits, consumer math, and fleet scale guidance

Each label creates ~6 NATS consumers for hierarchical prefix matching.
With 5 labels averaging 3 levels, an agent creates ~36 consumers total.
At 1000+ nodes, this is manageable with an external NATS cluster.

🤖 Generated with [Claude Code](https://claude.ai/code)