### PR TITLE
chore: move demo.tape to asset/

### DIFF
--- a/asset/demo.tape
+++ b/asset/demo.tape
@@ -1,5 +1,5 @@
 # OSAPI Demo Recording
-# Run with: vhs demo.tape
+# Run from the repo root with: vhs asset/demo.tape
 # Requires: vhs, tmux, osapi binary built in current directory
 
 Output asset/demo.gif


### PR DESCRIPTION
## Summary
- Relocate `demo.tape` from the repo root into `asset/demo.tape`, colocating the VHS source with its generated output (`asset/demo.gif`). Matches the convention used in \`~/git/grind\` and \`~/git/tlock\` where tape files live next to their GIFs under \`asset/\`.
- Update the internal run-command comment from \`vhs demo.tape\` to \`vhs asset/demo.tape\`.

Left alone: the plan doc \`docs/plans/2026-03-02-demo-recording-design.md\` still mentions the old root path — it's a historical design record, not current state, so no edit there.

## Test plan
- [x] \`ls asset/demo.tape\` exists, repo-root \`demo.tape\` gone
- [x] \`vhs asset/demo.tape\` still runs and regenerates \`asset/demo.gif\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)